### PR TITLE
feat: 도메인 fineeat.kro.kr 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build: .
     container_name: food-app
     ports:
-      - "8080:8080"
+      - "8081:8080"
     environment:
       SPRING_PROFILES_ACTIVE: prod
       DB_URL: jdbc:mysql://food-db.c3s0okm64zbr.ap-northeast-2.rds.amazonaws.com:3306/food?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8

--- a/src/main/java/project/food/global/config/SwaggerConfig.java
+++ b/src/main/java/project/food/global/config/SwaggerConfig.java
@@ -30,8 +30,11 @@ public class SwaggerConfig {
                         .version("v1.0.0"))
                 .servers(List.of(
                         new Server()
+                                .url("http://fineeat.kro.kr")
+                                .description("운영 서버"),
+                        new Server()
                                 .url("http://52.78.34.150")
-                                .description("로컬 서버")
+                                .description("EC2 서버")
                 ))
                 // Authorize 버튼에 JWT 인증 추가
                 .components(new Components()

--- a/src/main/java/project/food/global/config/WebConfig.java
+++ b/src/main/java/project/food/global/config/WebConfig.java
@@ -33,7 +33,9 @@ public class WebConfig implements WebMvcConfigurer {
                 "https://dtcam9thqu1os.cloudfront.net",
                 "https://food-web-page.s3.ap-northeast-2.amazonaws.com",
                 "http://food-web-page.s3-website.ap-northeast-2.amazonaws.com",
-                "http://52.78.34.150"
+                "http://52.78.34.150",
+                "http://fineeat.kro.kr",
+                "https://fineeat.kro.kr"
 
         ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));


### PR DESCRIPTION
## 요약
- `WebConfig`: `fineeat.kro.kr` CORS 허용 추가 (http/https)
- `SwaggerConfig`: `fineeat.kro.kr` 운영 서버로 추가
- `docker-compose.yml`: 포트 매핑 8080 → 8081 변경

## 테스트 계획
- [ ] 배포 후 `http://fineeat.kro.kr` 접속 확인
- [ ] Swagger UI에서 운영 서버 선택 확인
- [ ] CORS 정상 동작 확인
