### PR TITLE
feat: api.fineeat.kro.kr 도메인 설정 업데이트

### DIFF
--- a/src/main/java/project/food/global/config/SwaggerConfig.java
+++ b/src/main/java/project/food/global/config/SwaggerConfig.java
@@ -30,10 +30,10 @@ public class SwaggerConfig {
                         .version("v1.0.0"))
                 .servers(List.of(
                         new Server()
-                                .url("http://fineeat.kro.kr")
+                                .url("http://api.fineeat.kro.kr:8080")
                                 .description("운영 서버"),
                         new Server()
-                                .url("http://52.78.34.150")
+                                .url("http://52.78.34.150:8080")
                                 .description("EC2 서버")
                 ))
                 // Authorize 버튼에 JWT 인증 추가

--- a/src/main/java/project/food/global/config/WebConfig.java
+++ b/src/main/java/project/food/global/config/WebConfig.java
@@ -35,7 +35,8 @@ public class WebConfig implements WebMvcConfigurer {
                 "http://food-web-page.s3-website.ap-northeast-2.amazonaws.com",
                 "http://52.78.34.150",
                 "http://fineeat.kro.kr",
-                "https://fineeat.kro.kr"
+                "https://fineeat.kro.kr",
+                "http://api.fineeat.kro.kr:8080"
 
         ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));


### PR DESCRIPTION
## 요약
- `SwaggerConfig`: 운영 서버 URL을 `api.fineeat.kro.kr:8080`으로 변경
- `WebConfig`: `api.fineeat.kro.kr:8080` CORS 허용 추가

## 테스트 계획
- [ ] `http://api.fineeat.kro.kr:8080/swagger-ui/index.html` 접속 확인
- [ ] Swagger에서 API 호출 정상 동작 확인
