### PR TITLE
feat: 배포 후 Docker 이미지 자동 정리 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,9 @@ jobs:
             docker rm food-app || true
             sudo kill -9 $(sudo lsof -t -i:8080) || true
 
+            docker image prune -f
+            docker system prune -f --volumes=false
+
             docker run -d \
               --name food-app \
               --restart always \


### PR DESCRIPTION
## 요약
- 배포 후 `docker image prune`, `docker system prune`으로 불필요한 이미지 자동 제거
- EC2 디스크/메모리 부족으로 배포가 멈추는 문제 방지

## 배경
- EC2 메모리(911MB)가 부족해 `docker pull` 중 인스턴스가 멈추는 현상 발생
- 기존 이미지가 쌓여 디스크 597MB 낭비 확인

## 테스트 계획
- [ ] 배포 후 정상 완료 확인
- [ ] EC2 디스크/메모리 여유 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)