### PR TITLE
fix: kill -9 제거 및 Swagger URL HTTPS 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,6 @@ jobs:
 
             docker stop food-app || true
             docker rm food-app || true
-            sudo kill -9 $(sudo lsof -t -i:8080) || true
 
             docker image prune -f
             docker system prune -f --volumes=false

--- a/src/main/java/project/food/global/config/SwaggerConfig.java
+++ b/src/main/java/project/food/global/config/SwaggerConfig.java
@@ -30,11 +30,11 @@ public class SwaggerConfig {
                         .version("v1.0.0"))
                 .servers(List.of(
                         new Server()
-                                .url("http://api.fineeat.kro.kr:8080")
+                                .url("https://api.fineeat.kro.kr")
                                 .description("운영 서버"),
                         new Server()
-                                .url("http://52.78.34.150:8080")
-                                .description("EC2 서버")
+                                .url("http://localhost:8080")
+                                .description("로컬 서버")
                 ))
                 // Authorize 버튼에 JWT 인증 추가
                 .components(new Components()


### PR DESCRIPTION
## Summary
- 불필요한 `kill -9` 명령어 제거 (docker stop으로 graceful shutdown 처리)
- Swagger 서버 URL을 `https://api.fineeat.kro.kr`로 변경
- EC2 IP 직접 노출 제거, 로컬 개발 서버 URL 추가

## Test plan
- [ ] 배포 후 `/v3/api-docs`에서 서버 URL 확인
- [ ] Swagger UI에서 API 호출 정상 동작 확인
