### PR TITLE
fix: Swagger HTTPS URL 및 CORS 설정 재적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,6 @@ jobs:
 
             docker stop food-app || true
             docker rm food-app || true
-            sudo kill -9 $(sudo lsof -t -i:8080) || true
 
             docker image prune -f
             docker system prune -f --volumes=false

--- a/src/main/java/project/food/global/config/SwaggerConfig.java
+++ b/src/main/java/project/food/global/config/SwaggerConfig.java
@@ -30,11 +30,11 @@ public class SwaggerConfig {
                         .version("v1.0.0"))
                 .servers(List.of(
                         new Server()
-                                .url("http://api.fineeat.kro.kr:8080")
+                                .url("https://api.fineeat.kro.kr")
                                 .description("운영 서버"),
                         new Server()
-                                .url("http://52.78.34.150:8080")
-                                .description("EC2 서버")
+                                .url("http://localhost:8080")
+                                .description("로컬 서버")
                 ))
                 // Authorize 버튼에 JWT 인증 추가
                 .components(new Components()

--- a/src/main/java/project/food/global/config/WebConfig.java
+++ b/src/main/java/project/food/global/config/WebConfig.java
@@ -36,7 +36,8 @@ public class WebConfig implements WebMvcConfigurer {
                 "http://52.78.34.150",
                 "http://fineeat.kro.kr",
                 "https://fineeat.kro.kr",
-                "http://api.fineeat.kro.kr:8080"
+                "http://api.fineeat.kro.kr:8080",
+                "https://api.fineeat.kro.kr"
 
         ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));


### PR DESCRIPTION
## Summary
- 실수로 revert된 PR #84 변경사항 재적용
- 불필요한 `kill -9` 명령어 제거
- Swagger 서버 URL HTTPS 변경 (`https://api.fineeat.kro.kr`)
- CORS 허용 오리진에 `https://api.fineeat.kro.kr` 추가

