### PR TITLE
refactor: 포트폴리오 품질 개선 - 보안/성능/검증 전반 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -65,4 +74,5 @@ jobs:
               -e ADMIN_EMAIL=${{ secrets.ADMIN_EMAIL }} \
               -e ADMIN_PASSWORD=${{ secrets.ADMIN_PASSWORD }} \
               -e SPRING_CLOUD_AWS_S3_BUCKET=${{ secrets.AWS_S3_BUCKET }} \
+              -e CORS_ALLOWED_ORIGINS="${{ secrets.CORS_ALLOWED_ORIGINS }}" \
               ${{ secrets.ECR_REPOSITORY }}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ out/
 
 ### YAML ###
 .env
+.env.dev
 src/main/resources/application-secret.yml
 
 ### macOs ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
-# 1단계: 빌드
-FROM eclipse-temurin:17-jdk AS build
-WORKDIR /app
-COPY . .
-RUN ./gradlew build -x test
-
-# 2단계: 실행
 FROM eclipse-temurin:17-jre
 WORKDIR /app
-COPY --from=build /app/build/libs/*.jar app.jar
+COPY *.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,7 @@ dependencies {
 
     // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
+implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // Security

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,14 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: food-mysql
+    ports:
+      - "3307:3306"
+    env_file:
+      - .env.dev
+    volumes:
+      - mysql-data:/var/lib/mysql
+    restart: always
+
+volumes:
+  mysql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build: .
     container_name: food-app
     ports:
-      - "8081:8080"
+      - "8080:8080"
     environment:
       SPRING_PROFILES_ACTIVE: prod
       DB_URL: jdbc:mysql://food-db.c3s0okm64zbr.ap-northeast-2.rds.amazonaws.com:3306/food?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8
@@ -11,11 +11,15 @@ services:
       DB_PASSWORD: ${DB_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
       KAKAO_API_KEY: ${KAKAO_API_KEY}
+      SPRING_CLOUD_AWS_CREDENTIALS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+      SPRING_CLOUD_AWS_CREDENTIALS_SECRET_KEY: ${AWS_SECRET_KEY}
+      SPRING_CLOUD_AWS_S3_BUCKET: ${AWS_S3_BUCKET}
+      SPRING_CLOUD_AWS_REGION_STATIC: ${AWS_REGION}
+      ADMIN_EMAIL: ${ADMIN_EMAIL}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     volumes:
-      - uploads:/app/uploads
       - logs:/app/logs
     restart: always
 
 volumes:
-  uploads:
   logs:

--- a/src/main/java/project/food/FoodApplication.java
+++ b/src/main/java/project/food/FoodApplication.java
@@ -2,8 +2,9 @@ package project.food;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
 public class FoodApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/project/food/domain/comment/controller/CommentController.java
+++ b/src/main/java/project/food/domain/comment/controller/CommentController.java
@@ -70,7 +70,7 @@ public class CommentController {
 
         CommentResponseDto response = commentService.createComment(postId, memberId, requestDto);
 
-        log.info("✅ 댓글 작성 완료: commentId={}, postId={}", response.getId(), postId);
+        log.info("댓글 작성 완료: commentId={}, postId={}", response.getId(), postId);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -97,7 +97,7 @@ public class CommentController {
 
         List<CommentResponseDto> comments = commentService.getCommentsByPostId(postId);
 
-        log.info("✅ 댓글 목록 조회 완료: postId={}, commentCount={}", postId, comments.size());
+        log.info("댓글 목록 조회 완료: postId={}, commentCount={}", postId, comments.size());
 
         return ResponseEntity.ok(comments);
     }
@@ -125,7 +125,7 @@ public class CommentController {
 
         List<CommentResponseDto> comments = commentService.getCommentsByMemberId(memberId);
 
-        log.info("✅ 회원 댓글 목록 조회 완료: memberId={}, commentCount={}", memberId, comments.size());
+        log.info("회원 댓글 목록 조회 완료: memberId={}, commentCount={}", memberId, comments.size());
 
         return ResponseEntity.ok(comments);
     }
@@ -163,7 +163,7 @@ public class CommentController {
 
         CommentResponseDto response = commentService.updateComment(commentId, memberId, requestDto);
 
-        log.info("✅ 댓글 수정 완료: commentId={}", commentId);
+        log.info("댓글 수정 완료: commentId={}", commentId);
 
         return ResponseEntity.ok(response);
     }
@@ -192,11 +192,11 @@ public class CommentController {
             @Parameter(description = "삭제 요청자 회원 ID", required = true)
             @AuthenticationPrincipal Long memberId) {
 
-        log.info("댓글 삭제 요청: commentId={}, memberID={}, postId={}", commentId, memberId, postId);
+        log.info("댓글 삭제 요청: commentId={}, memberId={}, postId={}", commentId, memberId, postId);
 
         commentService.deleteComment(commentId, memberId);
 
-        log.info("✅ 댓글 삭제 완료: commentId={}", commentId);
+        log.info("댓글 삭제 완료: commentId={}", commentId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/project/food/domain/comment/entity/Comment.java
+++ b/src/main/java/project/food/domain/comment/entity/Comment.java
@@ -15,7 +15,7 @@ import project.food.global.common.BaseTimeEntity;
  * 기능:
  * - 게시글에 대한 작성
  * - 댓글에 대댓글 작성
- * - 댓글 수정/삭제 (작성자 권환)
+ * - 댓글 수정/삭제 (작성자 권한)
  *
  * 연관간계:
  * - Member (N:1) - 작성자
@@ -25,7 +25,11 @@ import project.food.global.common.BaseTimeEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "comments")
+@Table(name = "comments", indexes = {
+        @Index(name = "idx_comment_post_id",    columnList = "post_id"),
+        @Index(name = "idx_comment_member_id",  columnList = "member_id"),
+        @Index(name = "idx_comment_parent_id",  columnList = "parent_comment_id")
+})
 public class Comment extends BaseTimeEntity {
 
     @Id
@@ -59,7 +63,7 @@ public class Comment extends BaseTimeEntity {
      * - true: 논리 삭제된 댓글
      */
     @Column(nullable = false)
-    private boolean deleted =false;
+    private boolean deleted = false;
 
     @Builder
     public Comment(Post post, Member member, String content, Long parentCommentId) {

--- a/src/main/java/project/food/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/project/food/domain/comment/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package project.food.domain.comment.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -21,6 +22,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
      * @param postId 게시글 ID
      * @return 댓글 목록 (오래된 댓글이 먼저)
      */
+    @EntityGraph(attributePaths = {"member"})
     List<Comment> findByPost_IdOrderByCreatedAtAsc(Long postId);
 
     /**
@@ -30,6 +32,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
      * @param memberId 회원 ID
      * @return 댓글 목록 (최신 댓글이 먼저)
      */
+    @EntityGraph(attributePaths = {"member"})
     List<Comment> findByMember_IdAndDeletedFalseOrderByCreatedAtDesc(Long memberId);
 
     /**

--- a/src/main/java/project/food/domain/comment/service/CommentService.java
+++ b/src/main/java/project/food/domain/comment/service/CommentService.java
@@ -52,14 +52,14 @@ public class CommentService {
         // 1. 게시글 존재 확인
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> {
-                    log.error("❌ 게시글 찾기 실패: postId={}", postId);
+                    log.error("게시글 찾기 실패: postId={}", postId);
                     return new CustomException(ErrorCode.POST_NOT_FOUND);
                 });
 
         // 2. 회원 존재 확인
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> {
-                    log.error("❌ 회원 찾기 실패: memberId={}", memberId);
+                    log.error("회원 찾기 실패: memberId={}", memberId);
                     return new CustomException(ErrorCode.MEMBER_NOT_FOUND);
                 });
 
@@ -79,7 +79,7 @@ public class CommentService {
 
         Comment savedComment = commentRepository.save(comment);
 
-        log.info("✅ 댓글 생성 완료: commentId={}, postId={}, memberId={}, isReply={}",
+        log.info("댓글 생성 완료: commentId={}, postId={}, memberId={}, isReply={}",
                 savedComment.getId(), postId, memberId,
                 requestDto.getParentCommentId() != null);
 
@@ -99,13 +99,13 @@ public class CommentService {
 
         // 게시글 존재 확인
         if (!postRepository.existsById(postId)) {
-            log.error("❌ 게시글 존재하지 않음: postId={}", postId);
+            log.error("게시글 존재하지 않음: postId={}", postId);
             throw new CustomException(ErrorCode.POST_NOT_FOUND);
         }
 
         List<Comment> comments = commentRepository.findByPost_IdOrderByCreatedAtAsc(postId);
 
-        log.info("✅ 댓글 목록 조회 완료: postId={}, totalCount={}, deletedCount={}",
+        log.info("댓글 목록 조회 완료: postId={}, totalCount={}, deletedCount={}",
                 postId, comments.size(),
                 comments.stream().filter(Comment::isDeleted).count());
 
@@ -126,14 +126,14 @@ public class CommentService {
         log.debug("회원 댓글 목록 조회 시작: memberId={}", memberId);
 
         if (!memberRepository.existsById(memberId)) {
-            log.error("❌ 회원 존재하지 않음: memberId={}", memberId);
+            log.error("회원 존재하지 않음: memberId={}", memberId);
             throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
         }
 
         List<Comment> comments = commentRepository
                 .findByMember_IdAndDeletedFalseOrderByCreatedAtDesc(memberId);
 
-        log.info("✅ 회원 댓글 목록 조회 완료: memberId={}, commentCount={}",
+        log.info("회원 댓글 목록 조회 완료: memberId={}, commentCount={}",
                 memberId, comments.size());
 
         return comments.stream()
@@ -157,20 +157,20 @@ public class CommentService {
         // 1. 댓글 존재 확인
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> {
-                    log.error("❌ 댓글 찾기 실패: commentId={}", commentId);
+                    log.error("댓글 찾기 실패: commentId={}", commentId);
                     return new CustomException(ErrorCode.COMMENT_NOT_FOUND);
                 });
 
         // 2. 삭제된 댓글인지 확인
         if (comment.isDeleted()) {
-            log.warn("⚠️ 삭제된 댓글 수정 시도: commentId={}, memberId={}",
+            log.warn("삭제된 댓글 수정 시도: commentId={}, memberId={}",
                     commentId, memberId);
             throw new CustomException(ErrorCode.COMMENT_ALREADY_DELETED);
         }
 
         // 3. 작성자 본인 확인
         if (!comment.isWriter(memberId)) {
-            log.warn("⚠️ 댓글 수정 권한 없음: commentId={}, requestMemberId={}, writerMemberId={}",
+            log.warn("댓글 수정 권한 없음: commentId={}, requestMemberId={}, writerMemberId={}",
                     commentId, memberId, comment.getMember().getId());
             throw new CustomException(ErrorCode.COMMENT_AUTHOR_MISMATCH);
         }
@@ -179,7 +179,7 @@ public class CommentService {
         String oldContent = comment.getContent();
         comment.updateContent(requestDto.getContent());
 
-        log.info("✅ 댓글 수정 완료: commentId={}, memberId={}, contentChanged={}",
+        log.info("댓글 수정 완료: commentId={}, memberId={}, contentChanged={}",
                 commentId, memberId, !oldContent.equals(requestDto.getContent()));
 
         return CommentResponseDto.from(comment);
@@ -206,13 +206,13 @@ public class CommentService {
         // 1. 댓글 존재 확인
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> {
-                    log.error("❌ 댓글 찾기 실패: commentId={}", commentId);
+                    log.error("댓글 찾기 실패: commentId={}", commentId);
                     return new CustomException(ErrorCode.COMMENT_NOT_FOUND);
                 });
 
         // 2. 이미 삭제된 댓글인지 확인
         if (comment.isDeleted()) {
-            log.warn("⚠️ 이미 삭제된 댓글 삭제 시도: commentId={}, memberId={}",
+            log.warn("이미 삭제된 댓글 삭제 시도: commentId={}, memberId={}",
                     commentId, memberId);
             throw new CustomException(ErrorCode.COMMENT_ALREADY_DELETED);
         }
@@ -222,7 +222,7 @@ public class CommentService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         if (!comment.isWriter(memberId) && !requester.isAdmin()) {
-            log.warn("⚠️ 댓글 삭제 권한 없음: commentId={}, requestMemberId={}, writerMemberId={}",
+            log.warn("댓글 삭제 권한 없음: commentId={}, requestMemberId={}, writerMemberId={}",
                     commentId, memberId, comment.getMember().getId());
             throw new CustomException(ErrorCode.COMMENT_AUTHOR_MISMATCH);
         }
@@ -234,19 +234,19 @@ public class CommentService {
         if (hasReplies) {
             // 4-1. 대댓글이 있으면 논리 삭제 (좋아요는 유지)
             comment.softDelete();
-            log.info("✅ 댓글 논리 삭제 완료 (대댓글 있음): commentId={}, memberId={}",
+            log.info("댓글 논리 삭제 완료 (대댓글 있음): commentId={}, memberId={}",
                     commentId, memberId);
         } else {
             // 4-2. 대댓글이 없으면 완전 삭제
             Long parentCommentId = comment.getParentCommentId();
             boolean isReply = comment.isReply();
 
-            // ⭐ 댓글 좋아요 먼저 삭제 (외래키 제약조건)
+            // 댓글 좋아요 먼저 삭제 (외래키 제약조건)
             commentLikeRepository.deleteByCommentId(commentId);
             log.debug("댓글 좋아요 삭제 완료: commentId={}", commentId);
 
             commentRepository.delete(comment);
-            log.info("✅ 댓글 완전 삭제 완료: commentId={}, memberId={}, isReply={}",
+            log.info("댓글 완전 삭제 완료: commentId={}, memberId={}, isReply={}",
                     commentId, memberId, isReply);
 
             // 4-3. 대댓글이었다면 부모 댓글 정리
@@ -277,13 +277,13 @@ public class CommentService {
 
         Comment parentComment = commentRepository.findById(parentCommentId)
                 .orElseThrow(() -> {
-                    log.error("❌ 부모 댓글 찾기 실패: parentCommentId={}", parentCommentId);
+                    log.error("부모 댓글 찾기 실패: parentCommentId={}", parentCommentId);
                     return new CustomException(ErrorCode.INVALID_PARENT_COMMENT);
                 });
 
         // 부모 댓글이 같은 게시글에 속하는지 확인
         if (!parentComment.getPostId().equals(postId)) {
-            log.error("❌ 부모 댓글이 다른 게시글에 속함: parentCommentId={}, " +
+            log.error("부모 댓글이 다른 게시글에 속함: parentCommentId={}, " +
                             "expectedPostId={}, actualPostId={}",
                     parentCommentId, postId, parentComment.getPostId());
             throw new CustomException(ErrorCode.INVALID_PARENT_COMMENT);
@@ -291,12 +291,12 @@ public class CommentService {
 
         // 부모 댓글이 삭제되지 않았는지 확인
         if (parentComment.isDeleted()) {
-            log.error("❌ 삭제된 댓글에 대댓글 작성 시도: parentCommentId={}",
+            log.error("삭제된 댓글에 대댓글 작성 시도: parentCommentId={}",
                     parentCommentId);
             throw new CustomException(ErrorCode.INVALID_PARENT_COMMENT);
         }
 
-        log.debug("✅ 부모 댓글 검증 완료: parentCommentId={}", parentCommentId);
+        log.debug("부모 댓글 검증 완료: parentCommentId={}", parentCommentId);
     }
 
     /**
@@ -328,8 +328,9 @@ public class CommentService {
                 .existsByParentCommentId(parentCommentId);
 
         if (!hasRemainingReplies) {
+            commentLikeRepository.deleteByCommentId(parentCommentId);
             commentRepository.delete(parentComment);
-            log.info("✅ 부모 댓글 완전 삭제 완료 (모든 대댓글 삭제됨): parentCommentId={}",
+            log.info("부모 댓글 완전 삭제 완료 (모든 대댓글 삭제됨): parentCommentId={}",
                     parentCommentId);
         } else {
             log.debug("부모 댓글 정리 불필요 (대댓글 남아있음): parentCommentId={}",

--- a/src/main/java/project/food/domain/like/commentlike/controller/CommentLikeController.java
+++ b/src/main/java/project/food/domain/like/commentlike/controller/CommentLikeController.java
@@ -85,7 +85,7 @@ public class CommentLikeController {
     }
 
     /**
-     * 댓글의 졸아요 개수 및 사용자의 좋아요 여부 조회
+     * 댓글의 좋아요 개수 및 사용자의 좋아요 여부 조회
      * @param memberId
      * @param commentId
      * @return 200 OK + 좋아요 개수 및 사용자의 좋아요 여부
@@ -117,6 +117,7 @@ public class CommentLikeController {
     })
     @GetMapping("/likes/member/{memberId}")
     public ResponseEntity<List<CommentLikeResponseDto>> getLikedCommentsByMember(
+            @AuthenticationPrincipal Long requesterId,
             @PathVariable Long memberId) {
         List<CommentLikeResponseDto> responseDto = commentLikeService.getLikedCommentsByMember(memberId);
         return ResponseEntity.ok(responseDto);

--- a/src/main/java/project/food/domain/like/commentlike/entity/CommentLike.java
+++ b/src/main/java/project/food/domain/like/commentlike/entity/CommentLike.java
@@ -50,7 +50,7 @@ public class CommentLike extends BaseTimeEntity {
      * @param memberId
      * @return true: 본인의 좋아요, false: 타인의 좋아요
      */
-    public boolean inOwnedBy(Long memberId) {
+    public boolean isOwnedBy(Long memberId) {
         return this.member != null && this.member.getId().equals(memberId);
     }
 }

--- a/src/main/java/project/food/domain/like/commentlike/repository/CommentLikeRepository.java
+++ b/src/main/java/project/food/domain/like/commentlike/repository/CommentLikeRepository.java
@@ -75,6 +75,14 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
     void deleteByCommentId(Long commentId);
 
     /**
+     * 여러 게시글에 달린 댓글의 좋아요 일괄 삭제 (회원 탈퇴 시 사용)
+     * @param postIds 게시글 ID 목록
+     */
+    @Modifying
+    @Query("DELETE FROM CommentLike cl WHERE cl.comment.post.id IN :postIds")
+    void deleteByPostIdIn(@Param("postIds") List<Long> postIds);
+
+    /**
      * 특정 회원이 작성한 댓글에 달린 모든 좋아요 삭제 (회원 탈퇴 시 사용)
      * @param memberId
      */

--- a/src/main/java/project/food/domain/like/postlike/controller/PostLikeController.java
+++ b/src/main/java/project/food/domain/like/postlike/controller/PostLikeController.java
@@ -115,6 +115,7 @@ public class PostLikeController {
     })
     @GetMapping("/likes/member/{memberId}")
     public ResponseEntity<List<PostLikeResponseDto>> getLikedPostsByMember(
+            @AuthenticationPrincipal Long requesterId,
             @PathVariable Long memberId) {
         List<PostLikeResponseDto> responseDto = postLikeService.getLikedPostsByMember(memberId);
         return ResponseEntity.ok(responseDto);

--- a/src/main/java/project/food/domain/like/postlike/repository/PostLikeRepository.java
+++ b/src/main/java/project/food/domain/like/postlike/repository/PostLikeRepository.java
@@ -64,4 +64,12 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
      * @param postId
      */
     void deleteByPostId(Long postId);
+
+    /**
+     * 여러 게시글의 좋아요 일괄 삭제 (회원 탈퇴 시 사용)
+     * @param postIds 게시글 ID 목록
+     */
+    @org.springframework.data.jpa.repository.Modifying
+    @org.springframework.data.jpa.repository.Query("DELETE FROM PostLike pl WHERE pl.post.id IN :postIds")
+    void deleteByPostIdIn(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/project/food/domain/member/controller/MemberController.java
+++ b/src/main/java/project/food/domain/member/controller/MemberController.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -92,9 +94,10 @@ public class MemberController {
             @ApiResponse(responseCode = "403", description = "접근 권한 없음 (관리자만 접근 가능)")
     })
     @GetMapping
-    public ResponseEntity<List<MemberResponseDto>> getAllMembers() {
-        List<MemberResponseDto> members = memberService.getAllMembers();
-        return ResponseEntity.ok(members);
+    public ResponseEntity<Page<MemberResponseDto>> getAllMembers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(memberService.getAllMembers(PageRequest.of(page, size)));
     }
 
     /**
@@ -128,8 +131,9 @@ public class MemberController {
     @PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<MemberResponseDto> updateMember(
             @PathVariable Long id,
+            @AuthenticationPrincipal Long requesterId,
             @Valid @ModelAttribute MemberUpdateDto updateDto) {
-        MemberResponseDto responseDto = memberService.updateMember(id, updateDto);
+        MemberResponseDto responseDto = memberService.updateMember(id, requesterId, updateDto);
         return ResponseEntity.ok(responseDto);
     }
 
@@ -148,8 +152,9 @@ public class MemberController {
     @PutMapping("/{id}/password")
     public ResponseEntity<Void> updatePassword(
             @PathVariable Long id,
+            @AuthenticationPrincipal Long requesterId,
             @Valid @RequestBody PasswordChangeRequestDto requestDto) {
-        memberService.updatePassword(id, requestDto.getOldPassword(), requestDto.getNewPassword());
+        memberService.updatePassword(id, requesterId, requestDto.getOldPassword(), requestDto.getNewPassword());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/project/food/domain/member/entity/Member.java
+++ b/src/main/java/project/food/domain/member/entity/Member.java
@@ -34,8 +34,7 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private String password;
 
-    @Lob
-    @Column(name = "profile_image", columnDefinition = "LONGTEXT")
+    @Column(name = "profile_image")
     private String profileImage;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/project/food/domain/member/service/MemberService.java
+++ b/src/main/java/project/food/domain/member/service/MemberService.java
@@ -5,20 +5,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import project.food.domain.comment.entity.Comment;
 import project.food.domain.comment.repository.CommentRepository;
 import project.food.domain.like.commentlike.repository.CommentLikeRepository;
 import project.food.domain.like.postlike.repository.PostLikeRepository;
 import project.food.domain.member.dto.*;
 import project.food.domain.member.entity.Member;
 import project.food.domain.member.repository.MemberRepository;
-import project.food.domain.post.entity.Post;
 import project.food.domain.post.repository.PostRepository;
 import project.food.global.exception.CustomException;
 import project.food.global.exception.ErrorCode;
 import project.food.global.file.dto.UploadedFileInfo;
-import project.food.global.file.service.FileStorageService;
+import project.food.global.file.service.FileStorage;
 import project.food.global.jwt.JwtTokenProvider;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -35,7 +36,7 @@ public class MemberService {
     private final CommentLikeRepository commentLikeRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
-    private final FileStorageService fileStorage;
+    private final FileStorage fileStorage;
 
     /**
      * 회원가입
@@ -57,15 +58,13 @@ public class MemberService {
         // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
 
-        String profileImageUrl = null;
-        if (requestDto.getProfileImage() != null && !requestDto.getProfileImage().isEmpty()) {
-            UploadedFileInfo fileInfo = fileStorage.saveProfileImage(requestDto.getProfileImage());
-            profileImageUrl = fileInfo.getFileUrl();
-        }
-
-        // Entity 생성 시 URL 전달
-        Member member = requestDto.toEntity(encodedPassword, profileImageUrl);
+        Member member = requestDto.toEntity(encodedPassword, null);
         Member savedMember = memberRepository.save(member);
+
+        if (requestDto.getProfileImage() != null && !requestDto.getProfileImage().isEmpty()) {
+            UploadedFileInfo fileInfo = fileStorage.saveProfileImage(requestDto.getProfileImage(), savedMember.getId());
+            savedMember.updateProfile(savedMember.getName(), savedMember.getNickname(), fileInfo.getFileUrl());
+        }
 
         log.info("회원가입 완료: id = {}, email = {}", savedMember.getId(), savedMember.getEmail());
 
@@ -95,7 +94,7 @@ public class MemberService {
         // JWT 토큰 생성
         String accessToken = jwtTokenProvider.createAccessToken(
                 member.getId(), member.getEmail(), member.getRole().getKey());
-        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId(), member.getRole().getKey());
 
         log.info("로그인 성공: id = {}, email = {}", member.getId(), member.getEmail());
 
@@ -121,7 +120,7 @@ public class MemberService {
 
         String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getEmail(), member.getRole().getKey());
 
-        String refreshToken = jwtTokenProvider.createRefreshToken(memberId);
+        String refreshToken = jwtTokenProvider.createRefreshToken(memberId, member.getRole().getKey());
 
         log.info("토큰 재발급 완료 : memberId = {}", memberId);
 
@@ -159,22 +158,29 @@ public class MemberService {
     /**
      * 전체 회원 조회
      */
-    public List<MemberResponseDto> getAllMembers() {
-        return memberRepository.findAll().stream()
-                .map(MemberResponseDto::from)
-                .toList();
+    public Page<MemberResponseDto> getAllMembers(Pageable pageable) {
+        return memberRepository.findAll(pageable)
+                .map(MemberResponseDto::from);
     }
 
     /**
      * 회원 정보 수정
      */
     @Transactional
-    public MemberResponseDto updateMember(Long id, MemberUpdateDto updateDto) {
+    public MemberResponseDto updateMember(Long id, Long requesterId, MemberUpdateDto updateDto) {
         log.info("회원 정보 수정: id = {}", id);
 
         // 회원 조회
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 본인 또는 관리자만 수정 가능
+        Member requester = memberRepository.findById(requesterId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        if (!id.equals(requesterId) && !requester.isAdmin()) {
+            log.warn("회원 정보 수정 권한 없음: targetId = {}, requesterId = {}", id, requesterId);
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
 
         // 닉네임 변경 시 중복 확인
         if (!member.getNickname().equals(updateDto.getNickname())) {
@@ -185,7 +191,7 @@ public class MemberService {
 
         String profileImageUrl = member.getProfileImage();
         if (updateDto.getProfileImage() != null && !updateDto.getProfileImage().isEmpty()) {
-            UploadedFileInfo fileInfo = fileStorage.saveProfileImage(updateDto.getProfileImage());
+            UploadedFileInfo fileInfo = fileStorage.saveProfileImage(updateDto.getProfileImage(), id);
             profileImageUrl = fileInfo.getFileUrl();
         }
 
@@ -207,8 +213,14 @@ public class MemberService {
      * 비밀번호 변경
      */
     @Transactional
-    public void updatePassword(Long id, String oldPassword, String newPassword) {
+    public void updatePassword(Long id, Long requesterId, String oldPassword, String newPassword) {
         log.info("비밀번호 변경: id = {}", id);
+
+        // 본인만 변경 가능
+        if (!id.equals(requesterId)) {
+            log.warn("비밀번호 변경 권한 없음: targetId = {}, requesterId = {}", id, requesterId);
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
 
         // 회원 조회
         Member member = memberRepository.findById(id)
@@ -254,20 +266,16 @@ public class MemberService {
         // 회원의 댓글에 다른 사람이 누른 좋아요 삭제
         commentLikeRepository.deleteByCommentMemberId(id);
 
-        // 회원 게시글의 댓글에 달린 좋아요 + 게시글 좋아요 삭제
-        List<Post> posts = postRepository.findByMemberId(id);
-        for  (Post post : posts) {
-            for (Comment comment : post.getComments()) {
-                commentLikeRepository.deleteByCommentId(comment.getId());
-            }
-            postLikeRepository.deleteByPostId(post.getId());
+        // 회원 게시글의 댓글 좋아요 + 게시글 좋아요 일괄 삭제
+        List<Long> postIds = postRepository.findIdsByMemberId(id);
+        if (!postIds.isEmpty()) {
+            commentLikeRepository.deleteByPostIdIn(postIds);
+            postLikeRepository.deleteByPostIdIn(postIds);
+            postRepository.deleteAllByIdInBatch(postIds);
         }
 
-        // 회원 게시글 삭제 (cascade: post_image, post_tag, comments 자동 삭제)
-        postRepository.deleteAll(posts);
-
         // 다른 게시글에 작성한 회원의 댓글 삭제
-        commentRepository.deleteById(id);
+        commentRepository.deleteByMemberId(id);
 
         // 회원 삭제
         memberRepository.deleteById(id);

--- a/src/main/java/project/food/domain/post/controller/PostController.java
+++ b/src/main/java/project/food/domain/post/controller/PostController.java
@@ -7,8 +7,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +24,6 @@ import project.food.domain.post.service.PostService;
 import project.food.global.api.kakao.local.dto.KakaoKeywordResponse;
 import project.food.global.api.kakao.local.service.KakaoLocalService;
 
-import java.util.List;
 
 /**
  * Post Controller
@@ -57,7 +59,7 @@ public class PostController {
             @Parameter(description = "작성자 회원 ID", required = true)
             @AuthenticationPrincipal Long memberId,
             @Parameter(description = "게시글 생성 요청 데이터", required = true)
-            @ModelAttribute PostRequestDto request) {
+            @Valid @ModelAttribute PostRequestDto request) {
 
         log.info("게시글 생성 요청: memberId={}, title={}, restaurantId={}, rating={}, imageCount={}",
                 memberId,
@@ -68,7 +70,7 @@ public class PostController {
 
         PostResponseDto response = postService.createPost(memberId, request);
 
-        log.info("✅ 게시글 생성 완료: postId={}, memberId={}", response.getId(), memberId);
+        log.info("게시글 생성 완료: postId={}, memberId={}", response.getId(), memberId);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -82,13 +84,15 @@ public class PostController {
     @ApiResponse(responseCode = "200", description = "조회 성공",
             content = @Content(schema = @Schema(implementation = PostResponseDto.class)))
     @GetMapping
-    public ResponseEntity<List<PostResponseDto>> getAllPosts() {
+    public ResponseEntity<Page<PostResponseDto>> getAllPosts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
 
-        log.info("게시글 전체 목록 조회 요청");
+        log.info("게시글 전체 목록 조회 요청: page={}, size={}", page, size);
 
-        List<PostResponseDto> posts = postService.getAllPosts();
+        Page<PostResponseDto> posts = postService.getAllPosts(PageRequest.of(page, size));
 
-        log.info("✅ 게시글 전체 목록 조회 완료: postCount={}", posts.size());
+        log.info("게시글 전체 목록 조회 완료: totalElements={}", posts.getTotalElements());
 
         return ResponseEntity.ok(posts);
     }
@@ -114,7 +118,7 @@ public class PostController {
 
         PostResponseDto response = postService.getPost(postId);
 
-        log.info("✅ 게시글 상세 조회 완료: postId={}, title={}, viewCount={}",
+        log.info("게시글 상세 조회 완료: postId={}, title={}, viewCount={}",
                 postId, response.getTitle(), response.getViewCount());
 
         return ResponseEntity.ok(response);
@@ -142,7 +146,7 @@ public class PostController {
             @Parameter(description = "수정 요청자 회원 ID", required = true)
             @AuthenticationPrincipal Long memberId,
             @Parameter(description = "게시글 수정 데이터 (multipart/form-data)", required = true)
-            @ModelAttribute PostUpdateDto request) {
+            @Valid @ModelAttribute PostUpdateDto request) {
 
         log.info("게시글 수정 요청: postId={}, memberId={}, title={}, newImageCount={}, deleteImageCount={}",
                 postId,
@@ -153,7 +157,7 @@ public class PostController {
 
         PostResponseDto response = postService.updatePost(postId, memberId, request);
 
-        log.info("✅ 게시글 수정 완료: postId={}, memberId={}", postId, memberId);
+        log.info("게시글 수정 완료: postId={}, memberId={}", postId, memberId);
 
         return ResponseEntity.ok(response);
     }
@@ -182,7 +186,7 @@ public class PostController {
 
         postService.deletePost(postId, memberId);
 
-        log.info("✅ 게시글 삭제 완료: postId={}, memberId={}", postId, memberId);
+        log.info("게시글 삭제 완료: postId={}, memberId={}", postId, memberId);
 
         return ResponseEntity.noContent().build();
     }
@@ -200,16 +204,18 @@ public class PostController {
             @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
     })
     @GetMapping("/member/{memberId}")
-    public ResponseEntity<List<PostResponseDto>> getPostsByMember(
+    public ResponseEntity<Page<PostResponseDto>> getPostsByMember(
             @Parameter(description = "회원 ID", required = true)
-            @PathVariable Long memberId) {
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
 
         log.info("회원별 게시글 조회 요청: memberId={}", memberId);
 
-        List<PostResponseDto> posts = postService.getPostsByMember(memberId);
+        Page<PostResponseDto> posts = postService.getPostsByMember(memberId, PageRequest.of(page, size));
 
-        log.info("✅ 회원별 게시글 조회 완료: memberId={}, postCount={}",
-                memberId, posts.size());
+        log.info("회원별 게시글 조회 완료: memberId={}, postCount={}",
+                memberId, posts.getTotalElements());
 
         return ResponseEntity.ok(posts);
     }
@@ -224,16 +230,18 @@ public class PostController {
     @ApiResponse(responseCode = "200", description = "검색 성공",
             content = @Content(schema = @Schema(implementation = PostResponseDto.class)))
     @GetMapping("/search")
-    public ResponseEntity<List<PostResponseDto>> searchPosts(
+    public ResponseEntity<Page<PostResponseDto>> searchPosts(
             @Parameter(description = "검색 키워드", required = true, example = "맛집")
-            @RequestParam String keyword) {
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
 
         log.info("게시글 검색 요청: keyword={}", keyword);
 
-        List<PostResponseDto> posts = postService.searchPosts(keyword);
+        Page<PostResponseDto> posts = postService.searchPosts(keyword, PageRequest.of(page, size));
 
-        log.info("✅ 게시글 검색 완료: keyword={}, resultCount={}",
-                keyword, posts.size());
+        log.info("게시글 검색 완료: keyword={}, resultCount={}",
+                keyword, posts.getTotalElements());
 
         return ResponseEntity.ok(posts);
     }
@@ -262,7 +270,7 @@ public class PostController {
 
         KakaoKeywordResponse result = kakaoLocalService.searchPlaceByKeyword(keyword, page);
 
-        log.info("✅ 음식점 검색 완료: keyword={}, resultCount={}",
+        log.info("음식점 검색 완료: keyword={}, resultCount={}",
                 keyword, result.getDocuments().size());
 
         return ResponseEntity.ok(result);

--- a/src/main/java/project/food/domain/post/dto/PostUpdateDto.java
+++ b/src/main/java/project/food/domain/post/dto/PostUpdateDto.java
@@ -3,6 +3,7 @@ package project.food.domain.post.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,6 +22,7 @@ public class PostUpdateDto {
      * 게시글 제목
      */
     @Schema(description = "게시글 제목", example = "수정된 제목")
+    @NotBlank(message = "제목은 필수입니다.")
     @Size(max = 100, message = "제목은 100자 이내로 입력해주세요.")
     private String title;
 
@@ -28,6 +30,7 @@ public class PostUpdateDto {
      * 게시글 내용
      */
     @Schema(description = "게시글 내용", example = "수정된 내용입니다.")
+    @NotBlank(message = "내용은 필수입니다.")
     private String content;
 
     /**

--- a/src/main/java/project/food/domain/post/entity/Post.java
+++ b/src/main/java/project/food/domain/post/entity/Post.java
@@ -19,7 +19,11 @@ import java.util.List;
  * - BaseTimeEntity 상속으로 createdAt, updatedAt 자동관리
  */
 @Entity
-@Table(name = "post")
+@Table(name = "post", indexes = {
+        @Index(name = "idx_post_member_id",     columnList = "member_id"),
+        @Index(name = "idx_post_restaurant_id", columnList = "restaurant_id"),
+        @Index(name = "idx_post_created_at",    columnList = "created_at")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/project/food/domain/post/repository/PostRepository.java
+++ b/src/main/java/project/food/domain/post/repository/PostRepository.java
@@ -4,35 +4,34 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import project.food.domain.post.entity.Post;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-    /**
-     * 특정 회원이 작성한 게시글 목록 조회
-     *
-     * @param memberId 회원 Id
-     * @return 게시글 목록
-     */
-    List<Post> findByMemberId(Long memberId);
 
-    /**
-     * keyword 검색 키워드
-     * @param keyword 검색 키워드
-     * @return 게시글 목록
-     */
-    List<Post> findByTitleContaining(String keyword);
+    @EntityGraph(attributePaths = {"member", "restaurant"})
+    Page<Post> findByMemberId(Long memberId, Pageable pageable);
 
-    /**
-     * 최신순 정렬
-     * @return 최신 게시글 목록
-     */
-    List<Post> findAllByOrderByCreatedAtDesc();
+    @EntityGraph(attributePaths = {"member", "restaurant"})
+    Page<Post> findByTitleContaining(String keyword, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member", "restaurant"})
+    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     @EntityGraph(attributePaths = {"member"})
     Page<Post> findByRestaurant_IdOrderByCreatedAtDesc(Long restaurantId, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"member"})
     Page<Post> findByRestaurantIsNull(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member", "restaurant"})
+    Optional<Post> findWithDetailsById(Long id);
+
+    @Query("SELECT p.id FROM Post p WHERE p.member.id = :memberId")
+    List<Long> findIdsByMemberId(@Param("memberId") Long memberId);
 
 }

--- a/src/main/java/project/food/domain/post/service/PostService.java
+++ b/src/main/java/project/food/domain/post/service/PostService.java
@@ -2,6 +2,8 @@ package project.food.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,10 +21,11 @@ import project.food.domain.restaurant.repository.RestaurantRepository;
 import project.food.domain.tag.entity.PostTag;
 import project.food.domain.tag.entity.Tag;
 import project.food.domain.tag.repository.TagRepository;
+import project.food.domain.like.postlike.repository.PostLikeRepository;
 import project.food.global.exception.CustomException;
 import project.food.global.exception.ErrorCode;
 import project.food.global.file.dto.UploadedFileInfo;
-import project.food.global.file.service.FileStorageService;
+import project.food.global.file.service.FileStorage;
 
 import java.util.HashSet;
 import java.util.List;
@@ -42,9 +45,10 @@ public class PostService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final PostImageRepository postImageRepository;
-    private final FileStorageService fileStorageService;
+    private final FileStorage fileStorageService;
     private final RestaurantRepository restaurantRepository;
     private final TagRepository tagRepository;
+    private final PostLikeRepository postLikeRepository;
 
     /**
      * 게시글 생성
@@ -59,7 +63,7 @@ public class PostService {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> {
-                    log.error("❌ 회원 찾기 실패: memberId={}", memberId);
+                    log.error("회원 찾기 실패: memberId={}", memberId);
                     return new CustomException(ErrorCode.MEMBER_NOT_FOUND);
                 });
 
@@ -69,7 +73,7 @@ public class PostService {
             // 기존 맛집 ID로 연결
             restaurant = restaurantRepository.findById(request.getRestaurantId())
                     .orElseThrow(() -> {
-                        log.error("❌ 음식점 찾기 실패: restaurantId={}", request.getRestaurantId());
+                        log.error("음식점 찾기 실패: restaurantId={}", request.getRestaurantId());
                         return new CustomException(ErrorCode.RESTAURANT_NOT_FOUND);
                     });
         } else if (request.getPlaceId() != null) {
@@ -114,7 +118,7 @@ public class PostService {
             savePostTags(savedPost, request.getTagNames());
         }
 
-        log.info("✅ 게시글 생성 완료: postId={}, memberId={}, title={}, imageCount={}, tagCount={}",
+        log.info("게시글 생성 완료: postId={}, memberId={}, title={}, imageCount={}, tagCount={}",
                 savedPost.getId(), memberId, savedPost.getTitle(),
                 savedPost.getImages().size(), savedPost.getPostTags().size());
 
@@ -125,17 +129,16 @@ public class PostService {
      * 게시글 전체 목록 조회 (최신순)
      * @return 게시글 목록
      */
-    public List<PostResponseDto> getAllPosts() {
+    public Page<PostResponseDto> getAllPosts(Pageable pageable) {
 
         log.debug("게시글 전체 목록 조회 시작");
 
-        List<Post> posts = postRepository.findAllByOrderByCreatedAtDesc();
+        Page<PostResponseDto> posts = postRepository.findAllByOrderByCreatedAtDesc(pageable)
+                .map(PostResponseDto::from);
 
-        log.info("✅ 게시글 전체 목록 조회 완료: totalCount={}", posts.size());
+        log.info("게시글 전체 목록 조회 완료: totalCount={}", posts.getTotalElements());
 
-        return posts.stream()
-                .map(PostResponseDto::from)
-                .collect(Collectors.toList());
+        return posts;
     }
 
     /**
@@ -149,9 +152,9 @@ public class PostService {
 
         log.debug("게시글 상세 조회 시작: postId={}", postId);
 
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findWithDetailsById(postId)
                 .orElseThrow(() -> {
-                    log.error("❌ 게시글 찾기 실패: postId={}", postId);
+                    log.error("게시글 찾기 실패: postId={}", postId);
                     return new CustomException(ErrorCode.POST_NOT_FOUND);
                 });
 
@@ -161,7 +164,7 @@ public class PostService {
         log.debug("조회수 증가: postId={}, {} → {}",
                 postId, beforeViewCount, post.getViewCount());
 
-        log.info("✅ 게시글 상세 조회 완료: postId={}, title={}, viewCount={}",
+        log.info("게시글 상세 조회 완료: postId={}, title={}, viewCount={}",
                 postId, post.getTitle(), post.getViewCount());
 
         return PostResponseDto.from(post);
@@ -181,12 +184,12 @@ public class PostService {
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> {
-                    log.error("❌ 게시글 찾기 실패: postId={}", postId);
+                    log.error("게시글 찾기 실패: postId={}", postId);
                     return new CustomException(ErrorCode.POST_NOT_FOUND);
                 });
 
         if (!post.isWriter(memberId)) {
-            log.warn("⚠️ 게시글 수정 권한 없음: postId={}, requestMemberId={}, writerMemberId={}",
+            log.warn("게시글 수정 권한 없음: postId={}, requestMemberId={}, writerMemberId={}",
                     postId, memberId, post.getMember().getId());
             throw new CustomException(ErrorCode.POST_ACCESS_DENIED);
         }
@@ -205,7 +208,7 @@ public class PostService {
             if (!Objects.equals(currentRestaurantId, request.getRestaurantId())) {
                 Restaurant restaurant = restaurantRepository.findById(request.getRestaurantId())
                         .orElseThrow(() -> {
-                            log.error("❌ 음식점 찾기 실패: restaurantId={}", request.getRestaurantId());
+                            log.error("음식점 찾기 실패: restaurantId={}", request.getRestaurantId());
                             return new CustomException(ErrorCode.RESTAURANT_NOT_FOUND);
                         });
                 post.assignRestaurant(restaurant);
@@ -268,7 +271,7 @@ public class PostService {
             }
         }
 
-        log.info("✅ 게시글 수정 완료: postId={}, memberId={}, currentImageCount={}, tagCount={}",
+        log.info("게시글 수정 완료: postId={}, memberId={}, currentImageCount={}, tagCount={}",
                 postId, memberId, post.getImages().size(), post.getPostTags().size());
 
         return PostResponseDto.from(post);
@@ -287,7 +290,7 @@ public class PostService {
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> {
-                    log.error("❌ 게시글 찾기 실패: postId={}", postId);
+                    log.error("게시글 찾기 실패: postId={}", postId);
                     return new CustomException(ErrorCode.POST_NOT_FOUND);
                 });
 
@@ -295,7 +298,7 @@ public class PostService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         if (!post.isWriter(memberId) && !requester.isAdmin()) {
-            log.warn("⚠️ 게시글 삭제 권한 없음: postId={}, requestMemberId={}, writerMemberId={}",
+            log.warn("게시글 삭제 권한 없음: postId={}, requestMemberId={}, writerMemberId={}",
                     postId, memberId, post.getMember().getId());
             throw new CustomException(ErrorCode.POST_ACCESS_DENIED);
         }
@@ -311,9 +314,11 @@ public class PostService {
             log.debug("게시글 이미지 파일 삭제 완료: postId={}", postId);
         }
 
+        postLikeRepository.deleteByPostId(postId);
+
         postRepository.delete(post);
 
-        log.info("✅ 게시글 삭제 완료: postId={}, memberId={}, deletedImages={}",
+        log.info("게시글 삭제 완료: postId={}, memberId={}, deletedImages={}",
                 postId, memberId, filePaths.size());
     }
 
@@ -322,18 +327,17 @@ public class PostService {
      * @param memberId 회원 ID
      * @return 해당 회원의 게시글 목록
      */
-    public List<PostResponseDto> getPostsByMember(Long memberId) {
+    public Page<PostResponseDto> getPostsByMember(Long memberId, Pageable pageable) {
 
         log.debug("회원 게시글 목록 조회 시작: memberId={}", memberId);
 
-        List<Post> posts = postRepository.findByMemberId(memberId);
+        Page<PostResponseDto> posts = postRepository.findByMemberId(memberId, pageable)
+                .map(PostResponseDto::from);
 
-        log.info("✅ 회원 게시글 목록 조회 완료: memberId={}, postCount={}",
-                memberId, posts.size());
+        log.info("회원 게시글 목록 조회 완료: memberId={}, postCount={}",
+                memberId, posts.getTotalElements());
 
-        return posts.stream()
-                .map(PostResponseDto::from)
-                .collect(Collectors.toList());
+        return posts;
     }
 
     /**
@@ -341,18 +345,17 @@ public class PostService {
      * @param keyword 검색 키워드
      * @return 검색 결과 게시글 목록
      */
-    public List<PostResponseDto> searchPosts(String keyword) {
+    public Page<PostResponseDto> searchPosts(String keyword, Pageable pageable) {
 
         log.debug("게시글 검색 시작: keyword={}", keyword);
 
-        List<Post> posts = postRepository.findByTitleContaining(keyword);
+        Page<PostResponseDto> posts = postRepository.findByTitleContaining(keyword, pageable)
+                .map(PostResponseDto::from);
 
-        log.info("✅ 게시글 검색 완료: keyword={}, resultCount={}",
-                keyword, posts.size());
+        log.info("게시글 검색 완료: keyword={}, resultCount={}",
+                keyword, posts.getTotalElements());
 
-        return posts.stream()
-                .map(PostResponseDto::from)
-                .collect(Collectors.toList());
+        return posts;
     }
 
     /**
@@ -380,7 +383,7 @@ public class PostService {
             post.addPostTag(postTag);
         }
 
-        log.info("✅ 태그 저장 완료: postId={}, tagCount={}", post.getId(), distinctTagNames.size());
+        log.info("태그 저장 완료: postId={}, tagCount={}", post.getId(), distinctTagNames.size());
     }
 
     /**
@@ -394,7 +397,7 @@ public class PostService {
                 post.getId(), imageFiles.size());
 
         // 파일 저장
-        List<UploadedFileInfo> uploadedFiles = fileStorageService.storeFiles(imageFiles);
+        List<UploadedFileInfo> uploadedFiles = fileStorageService.storeFiles(imageFiles, post.getMember().getId());
 
         log.debug("파일 스토리지 저장 완료: postId={}, savedCount={}",
                 post.getId(), uploadedFiles.size());
@@ -421,7 +424,7 @@ public class PostService {
                     postImage.getId(), fileInfo.getOriginalFileName(), fileInfo.getFileSize());
         }
 
-        log.info("✅ 이미지 저장 완료: postId={}, savedImageCount={}, totalImageCount={}",
+        log.info("이미지 저장 완료: postId={}, savedImageCount={}, totalImageCount={}",
                 post.getId(), savedCount, post.getImages().size());
     }
 
@@ -439,13 +442,13 @@ public class PostService {
         for (Long imageId : imageIds) {
             PostImage postImage = postImageRepository.findById(imageId)
                     .orElseThrow(() -> {
-                        log.error("❌ 이미지 찾기 실패: imageId={}", imageId);
+                        log.error("이미지 찾기 실패: imageId={}", imageId);
                         return new CustomException(ErrorCode.FILE_NOT_FOUND);
                     });
 
             // 게시글 소유 확인
             if (!postImage.getPost().getId().equals(post.getId())) {
-                log.warn("⚠️ 이미지가 다른 게시글에 속함: imageId={}, requestPostId={}, actualPostId={}",
+                log.warn("이미지가 다른 게시글에 속함: imageId={}, requestPostId={}, actualPostId={}",
                         imageId, post.getId(), postImage.getPost().getId());
                 throw new CustomException(ErrorCode.POST_ACCESS_DENIED);
             }
@@ -465,7 +468,7 @@ public class PostService {
                     imageId, postImage.getOriginalFileName());
         }
 
-        log.info("✅ 이미지 삭제 완료: postId={}, deletedCount={}, remainingCount={}",
+        log.info("이미지 삭제 완료: postId={}, deletedCount={}, remainingCount={}",
                 post.getId(), deletedCount, post.getImages().size());
     }
 }

--- a/src/main/java/project/food/domain/tag/controller/TagController.java
+++ b/src/main/java/project/food/domain/tag/controller/TagController.java
@@ -51,7 +51,7 @@ public class TagController {
 
         TagResponseDto response = tagService.createTag(request);
 
-        log.info("✅태그 생성 완료: tagId={}", response.getId());
+        log.info("태그 생성 완료: tagId={}", response.getId());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
 
@@ -71,7 +71,7 @@ public class TagController {
 
         List<TagResponseDto> tags = tagService.getAllTags();
 
-        log.info("✅태그 전체 목록 조회 완료: tagCount={}", tags.size());
+        log.info("태그 전체 목록 조회 완료: tagCount={}", tags.size());
 
         return ResponseEntity.ok(tags);
     }
@@ -97,7 +97,7 @@ public class TagController {
         TagResponseDto response =
                 tagService.getTag(tagId);
 
-        log.info("✅태그 조회 완료: tagId={}, name={}",
+        log.info("태그 조회 완료: tagId={}, name={}",
                 tagId, response.getName());
 
         return ResponseEntity.ok(response);
@@ -126,7 +126,7 @@ public class TagController {
 
         TagResponseDto response = tagService.updateTag(tagId, request);
 
-        log.info("✅태그 수정 완료: tagId={}", tagId);
+        log.info("태그 수정 완료: tagId={}", tagId);
 
         return ResponseEntity.ok(response);
 
@@ -152,7 +152,7 @@ public class TagController {
 
         tagService.deleteTag(tagId);
 
-        log.info("✅ 태그 삭제 완료: tagId={}", tagId);
+        log.info("태그 삭제 완료: tagId={}", tagId);
 
         return ResponseEntity.noContent().build();
 
@@ -176,7 +176,7 @@ public class TagController {
 
         List<TagResponseDto> tags = tagService.searchTags(keyword);
 
-        log.info("✅ 태그 검색 완료: keyword={}, resultCount={}", keyword, tags.size());
+        log.info("태그 검색 완료: keyword={}, resultCount={}", keyword, tags.size());
 
         return ResponseEntity.ok(tags);
 

--- a/src/main/java/project/food/domain/tag/service/TagService.java
+++ b/src/main/java/project/food/domain/tag/service/TagService.java
@@ -30,17 +30,17 @@ public class TagService {
         log.debug("태그 생성 시작: name={}", request.getName());
 
         if (tagRepository.existsByName(request.getName())) {
-            log.warn("⚠️태그 이름 중복: name={}", request.getName());
+            log.warn("태그 이름 중복: name={}", request.getName());
             throw new CustomException(ErrorCode.DUPLICATE_TAG_NAME);
         }
 
         Tag tag = Tag.builder()
-                .name((request.getName()))
+                .name(request.getName())
                 .build();
 
         Tag savedTag = tagRepository.save(tag);
 
-        log.info("✅태그 생성 완료: tagId={}, name={}", savedTag.getId(), request.getName());
+        log.info("태그 생성 완료: tagId={}, name={}", savedTag.getId(), request.getName());
 
         return TagResponseDto.from(savedTag);
     }
@@ -53,7 +53,7 @@ public class TagService {
 
         List<Tag> tags = tagRepository.findAll();
 
-        log.info("✅태그 전체 목록 조회 완료: totalCount={}", tags.size());
+        log.info("태그 전체 목록 조회 완료: totalCount={}", tags.size());
 
         return tags.stream()
                 .map(TagResponseDto::from)
@@ -69,11 +69,11 @@ public class TagService {
 
         Tag tag = tagRepository.findById(tagId)
                 .orElseThrow(() -> {
-                    log.error("❌태그 찾기 실패: tagId={}", tagId);
+                    log.error("태그 찾기 실패: tagId={}", tagId);
                     return new CustomException(ErrorCode.TAG_NOT_FOUND);
                 });
 
-        log.info("✅태그 조회 완료: tagId={}, name={}", tag.getId(), tag.getName());
+        log.info("태그 조회 완료: tagId={}, name={}", tag.getId(), tag.getName());
 
         return TagResponseDto.from(tag);
     }
@@ -88,12 +88,12 @@ public class TagService {
 
         Tag tag = tagRepository.findById(tagId)
                 .orElseThrow(() -> {
-                    log.error("❌태그 찾기 실패: tagId={}", tagId);
+                    log.error("태그 찾기 실패: tagId={}", tagId);
                     return new CustomException(ErrorCode.TAG_NOT_FOUND);
                 });
 
         if (tagRepository.existsByName(request.getName()) && !tag.getName().equals(request.getName())) {
-            log.warn("⚠️태그 이름 중복: name={}", request.getName());
+            log.warn("태그 이름 중복: name={}", request.getName());
 
             throw new CustomException(ErrorCode.DUPLICATE_TAG_NAME);
         }
@@ -101,7 +101,7 @@ public class TagService {
         String oldName = tag.getName();
         tag.updateName(request.getName());
 
-        log.info("✅태그 수정 완료: tagId={}, {} -> {}", tagId, oldName, tag.getName());
+        log.info("태그 수정 완료: tagId={}, {} -> {}", tagId, oldName, tag.getName());
 
         return TagResponseDto.from(tag);
     }
@@ -115,13 +115,13 @@ public class TagService {
 
         Tag tag = tagRepository.findById(tagId)
                 .orElseThrow(() -> {
-                    log.error("❌태그 찾기 실패: tagId={}", tagId);
+                    log.error("태그 찾기 실패: tagId={}", tagId);
                     return new CustomException(ErrorCode.TAG_NOT_FOUND);
                 });
 
         tagRepository.delete(tag);
 
-        log.info("✅태그 삭제 완료: tagId={}, name={}", tagId, tag.getName());
+        log.info("태그 삭제 완료: tagId={}, name={}", tagId, tag.getName());
     }
 
     /**
@@ -132,7 +132,7 @@ public class TagService {
 
         List<Tag> tags = tagRepository.findByNameContaining(keyword);
 
-        log.info("✅태그 검색 완료: keyword={}, resultCount={}", keyword, tags.size());
+        log.info("태그 검색 완료: keyword={}, resultCount={}", keyword, tags.size());
 
         return tags.stream()
                 .map(TagResponseDto::from)

--- a/src/main/java/project/food/global/api/kakao/geo/service/KakaoGeoService.java
+++ b/src/main/java/project/food/global/api/kakao/geo/service/KakaoGeoService.java
@@ -63,7 +63,7 @@ public class KakaoGeoService {
             }
 
             long elapsed = System.currentTimeMillis() - startedAt;
-            log.info("✅ [KAKAO][GEO] 성공 address={} lat={} lng={} elapsedMs={}",
+            log.info("[KAKAO][GEO] 성공 address={} lat={} lng={} elapsedMs={}",
                     address, body.getLatitude(), body.getLongitude(), elapsed);
 
             return body;
@@ -77,7 +77,7 @@ public class KakaoGeoService {
 
         } catch (RestClientException e) {
             long elapsed = System.currentTimeMillis() - startedAt;
-            log.error("⚠️ [KAKAO][GEO] 호출 오류 address={} elapsedMs={} error={}",
+            log.error("[KAKAO][GEO] 호출 오류 address={} elapsedMs={} error={}",
                     address, elapsed, e.getMessage());
             throw new CustomException(ErrorCode.KAKAO_API_ERROR);
         }
@@ -87,17 +87,17 @@ public class KakaoGeoService {
         HttpStatusCode status = e.getStatusCode();
 
         if (status == HttpStatus.UNAUTHORIZED) {
-            log.error("❌ [KAKAO][GEO] 인증 실패 {}={} status={} msg={}",
+            log.error("[KAKAO][GEO] 인증 실패 {}={} status={} msg={}",
                     keyName, keyValue, status, e.getMessage());
             throw new CustomException(ErrorCode.KAKAO_API_UNAUTHORIZED);
         }
         if (status == HttpStatus.TOO_MANY_REQUESTS) {
-            log.error("❌ [KAKAO][GEO] 호출 한도 초과 {}={} status={} msg={}",
+            log.error("[KAKAO][GEO] 호출 한도 초과 {}={} status={} msg={}",
                     keyName, keyValue, status, e.getMessage());
             throw new CustomException(ErrorCode.KAKAO_API_RATE_LIMIT);
         }
 
-        log.error("❌ [KAKAO][GEO] HTTP 오류 {}={} status={} msg={}",
+        log.error("[KAKAO][GEO] HTTP 오류 {}={} status={} msg={}",
                 keyName, keyValue, status, e.getMessage());
     }
 }

--- a/src/main/java/project/food/global/api/kakao/local/service/KakaoLocalService.java
+++ b/src/main/java/project/food/global/api/kakao/local/service/KakaoLocalService.java
@@ -41,7 +41,7 @@ public class KakaoLocalService {
                 .queryParam("query", keyword)   // "강남맛집" 그대로 넣어도 됨
                 .queryParam("page", page)
                 .queryParam("size", 15)
-                .encode(StandardCharsets.UTF_8) // ✅ 여기서 인코딩
+                .encode(StandardCharsets.UTF_8) // 여기서 인코딩
                 .build()
                 .toUri();
 
@@ -69,7 +69,7 @@ public class KakaoLocalService {
             int count = (body.getDocuments() == null) ? 0 : body.getDocuments().size();
             long elapsed = System.currentTimeMillis() - startedAt;
 
-            log.info("✅ [KAKAO][LOCAL] 성공 keyword={} page={} count={} elapsedMs={}",
+            log.info("[KAKAO][LOCAL] 성공 keyword={} page={} count={} elapsedMs={}",
                     keyword, page, count, elapsed);
 
             return body;
@@ -83,7 +83,7 @@ public class KakaoLocalService {
 
         } catch (RestClientException e) {
             long elapsed = System.currentTimeMillis() - startedAt;
-            log.error("⚠️ [KAKAO][LOCAL] 호출 오류 keyword={} page={} elapsedMs={} error={}",
+            log.error("[KAKAO][LOCAL] 호출 오류 keyword={} page={} elapsedMs={} error={}",
                     keyword, page, elapsed, e.getMessage());
             throw new CustomException(ErrorCode.KAKAO_API_ERROR);
         }
@@ -93,17 +93,17 @@ public class KakaoLocalService {
         HttpStatusCode status = e.getStatusCode();
 
         if (status == HttpStatus.UNAUTHORIZED) {
-            log.error("❌ [KAKAO][LOCAL] 인증 실패 {}={} status={} msg={}",
+            log.error("[KAKAO][LOCAL] 인증 실패 {}={} status={} msg={}",
                     keyName, keyValue, status, e.getMessage());
             throw new CustomException(ErrorCode.KAKAO_API_UNAUTHORIZED);
         }
         if (status == HttpStatus.TOO_MANY_REQUESTS) {
-            log.error("❌ [KAKAO][LOCAL] 호출 한도 초과 {}={} status={} msg={}",
+            log.error("[KAKAO][LOCAL] 호출 한도 초과 {}={} status={} msg={}",
                     keyName, keyValue, status, e.getMessage());
             throw new CustomException(ErrorCode.KAKAO_API_RATE_LIMIT);
         }
 
-        log.error("❌ [KAKAO][LOCAL] HTTP 오류 {}={} status={} msg={}",
+        log.error("[KAKAO][LOCAL] HTTP 오류 {}={} status={} msg={}",
                 keyName, keyValue, status, e.getMessage());
     }
 }

--- a/src/main/java/project/food/global/config/DataInitializer.java
+++ b/src/main/java/project/food/global/config/DataInitializer.java
@@ -27,7 +27,7 @@ public class DataInitializer {
     private String adminPassword;
 
     @Bean
-    @Profile({"dev", "local"})
+    @Profile({"dev", "prod"})
     public CommandLineRunner initData() {
         return args -> {
             log.info("============================");
@@ -68,7 +68,6 @@ public class DataInitializer {
 
         log.info("관리자 계정 생성 완료");
         log.info(" - 이메일: {}", adminEmail);
-        log.info(" - 암호화된 비밀번호: {}", encodedPassword);
         log.info(" - 권한: ADMIN");
     }
 }

--- a/src/main/java/project/food/global/config/FileStorageConfig.java
+++ b/src/main/java/project/food/global/config/FileStorageConfig.java
@@ -1,44 +1,13 @@
 package project.food.global.config;
 
-import jakarta.annotation.PostConstruct;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
-import java.io.File;
-
-/**
- * 파일 저장 설정
- * - application.yml의 파일 업로드 설정을 관리
- */
-@Slf4j
 @Configuration
 @Getter
 public class FileStorageConfig {
 
-    @Value("${file.upload.dir}")
-    private String uploadDir;
-
     @Value("${file.upload.max-file-count}")
     private int maxFileCount;
-
-    @PostConstruct  // 스프링 빈 초기화 후 자동 실행
-    public void init() {
-        log.info("파일 스토리지 설정 초기화: uploadDir={}, maxFileCount={}",
-                uploadDir, maxFileCount);
-
-        File uploadDirectory = new File(uploadDir);
-
-        if (!uploadDirectory.exists()) {
-            boolean created = uploadDirectory.mkdirs();
-            if (created) {
-                log.info("✅ 업로드 디렉토리 생성 완료: {}", uploadDir);
-            } else {
-                log.error("❌ 업로드 디렉토리 생성 실패: {}", uploadDir);
-            }
-        } else {
-            log.info("✅ 업로드 디렉토리 존재 확인: {}", uploadDir);
-        }
-    }
 }

--- a/src/main/java/project/food/global/config/S3Config.java
+++ b/src/main/java/project/food/global/config/S3Config.java
@@ -4,12 +4,14 @@ import io.awspring.cloud.s3.S3Template;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
+@Profile("prod")
 public class S3Config {
 
     @Value("${spring.cloud.aws.credentials.access-key}")

--- a/src/main/java/project/food/global/config/SecurityConfig.java
+++ b/src/main/java/project/food/global/config/SecurityConfig.java
@@ -36,15 +36,16 @@ public class SecurityConfig {
                                 .accessDeniedHandler(jwtAccessDeniedHandler))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/members",
+                                "/",
+                                "/uploads/**",
                                 "/api/members/login",
                                 "/api/members/refresh",
                                 "/api/members/check-email",
                                 "/api/members/check-nickname",
                                 "/swagger-ui/**",
-                                "/v3/api-docs/**",
-                                "/uploads/**"
+                                "/v3/api-docs/**"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/members").permitAll()
                         .requestMatchers(HttpMethod.GET,
                                 "/api/posts/**",
                                 "/api/tags/**",
@@ -54,7 +55,12 @@ public class SecurityConfig {
                                 "/api/members/{memberId}/comments"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET,
+                                "/api/posts/likes/member/**",
+                                "/api/comments/likes/member/**"
+                        ).authenticated()
+                        .requestMatchers(HttpMethod.GET,
                                 "/api/members").hasRole("ADMIN")
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/project/food/global/config/WebConfig.java
+++ b/src/main/java/project/food/global/config/WebConfig.java
@@ -1,5 +1,6 @@
 package project.food.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -8,10 +9,14 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
@@ -23,23 +28,12 @@ public class WebConfig implements WebMvcConfigurer {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(
-                "http://localhost:5500",
-                "http://127.0.0.1:5500",
-                "http://localhost:5501",
-                "http://127.0.0.1:5501",
-                "http://localhost:8000",
-                "http://127.0.0.1:8000",
-                "https://dtcam9thqu1os.cloudfront.net",
-                "https://food-web-page.s3.ap-northeast-2.amazonaws.com",
-                "http://food-web-page.s3-website.ap-northeast-2.amazonaws.com",
-                "http://52.78.34.150",
-                "http://fineeat.kro.kr",
-                "https://fineeat.kro.kr",
-                "http://api.fineeat.kro.kr:8080",
-                "https://api.fineeat.kro.kr"
-
-        ));
+        configuration.setAllowedOrigins(
+                Arrays.stream(allowedOrigins.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .toList()
+        );
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/project/food/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/project/food/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 /**
  * 전역 예외 처리 핸들러
@@ -34,7 +35,7 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * Validation 에외 처리
+     * Validation 예외 처리
      * @Valid 검증 실패 시 발생
      * @param e MethodArgumentNotValidException
      * @return ErrorResponse
@@ -64,6 +65,12 @@ public class GlobalExceptionHandler {
         ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
 
         return ResponseEntity.status(ErrorCode.METHOD_NOT_ALLOWED.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException e) {
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return ResponseEntity.status(404).body(response);
     }
 
     /**

--- a/src/main/java/project/food/global/file/service/FileStorage.java
+++ b/src/main/java/project/food/global/file/service/FileStorage.java
@@ -1,0 +1,14 @@
+package project.food.global.file.service;
+
+import org.springframework.web.multipart.MultipartFile;
+import project.food.global.file.dto.UploadedFileInfo;
+
+import java.util.List;
+
+public interface FileStorage {
+    UploadedFileInfo savePostImage(MultipartFile file, Long memberId);
+    UploadedFileInfo saveProfileImage(MultipartFile file, Long memberId);
+    List<UploadedFileInfo> storeFiles(List<MultipartFile> files, Long memberId);
+    void deleteFile(String path);
+    void deleteFiles(List<String> paths);
+}

--- a/src/main/java/project/food/global/file/service/FileStorageService.java
+++ b/src/main/java/project/food/global/file/service/FileStorageService.java
@@ -3,6 +3,7 @@ package project.food.global.file.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import project.food.global.config.FileStorageConfig;
@@ -20,9 +21,10 @@ import java.util.List;
 import java.util.UUID;
 
 @Service
+@Profile("prod")
 @RequiredArgsConstructor
 @Slf4j
-public class FileStorageService {
+public class FileStorageService implements FileStorage {
 
     private final FileStorageConfig fileStorageConfig;
     private final S3Client s3Client;
@@ -39,12 +41,12 @@ public class FileStorageService {
     /**
      * 단일 파일 저장
      */
-    private UploadedFileInfo storeFile(MultipartFile file, String subDir) {
+    private UploadedFileInfo storeFile(MultipartFile file, String subDir, Long memberId) {
         validateFile(file);
 
         String originalFileName = file.getOriginalFilename();
         String storedFileName = generateStoredFileName(originalFileName);
-        String s3Key = subDir + "/" + storedFileName;
+        String s3Key = subDir + "/" + memberId + "/" + storedFileName;
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -72,24 +74,27 @@ public class FileStorageService {
         }
     }
 
-    public UploadedFileInfo savePostImage(MultipartFile file) {
-        return storeFile(file, "post");
+    @Override
+    public UploadedFileInfo savePostImage(MultipartFile file, Long memberId) {
+        return storeFile(file, "post", memberId);
     }
 
-    public UploadedFileInfo saveProfileImage(MultipartFile file) {
-        return storeFile(file, "profile");
+    @Override
+    public UploadedFileInfo saveProfileImage(MultipartFile file, Long memberId) {
+        return storeFile(file, "profile", memberId);
     }
 
     /**
      * 여러 파일 저장
      */
-    public List<UploadedFileInfo> storeFiles(List<MultipartFile> files) {
+    @Override
+    public List<UploadedFileInfo> storeFiles(List<MultipartFile> files, Long memberId) {
 
-        log.info("다중 파일 저장 시작: fileCount={}, maxAllowed={}",
-                files.size(), fileStorageConfig.getMaxFileCount());
+        log.info("다중 파일 저장 시작: memberId={}, fileCount={}, maxAllowed={}",
+                memberId, files.size(), fileStorageConfig.getMaxFileCount());
 
         if (files.size() > fileStorageConfig.getMaxFileCount()) {
-            log.warn("⚠️ 파일 개수 초과: requestCount={}, maxAllowed={}",
+            log.warn("파일 개수 초과: requestCount={}, maxAllowed={}",
                     files.size(), fileStorageConfig.getMaxFileCount());
             throw new FileUploadException(ErrorCode.FILE_COUNT_EXCEEDED);
         }
@@ -100,7 +105,7 @@ public class FileStorageService {
 
         for (MultipartFile file : files) {
             if (!file.isEmpty()) {
-                UploadedFileInfo fileInfo = savePostImage(file);
+                UploadedFileInfo fileInfo = savePostImage(file, memberId);
                 uploadedFiles.add(fileInfo);
                 successCount++;
             } else {
@@ -109,8 +114,8 @@ public class FileStorageService {
             }
         }
 
-        log.info("✅ 다중 파일 저장 완료: totalFiles={}, successCount={}, emptyCount={}",
-                files.size(), successCount, emptyCount);
+        log.info("다중 파일 저장 완료: memberId={}, totalFiles={}, successCount={}, emptyCount={}",
+                memberId, files.size(), successCount, emptyCount);
 
         return uploadedFiles;
     }
@@ -133,10 +138,10 @@ public class FileStorageService {
                     .build();
 
             s3Client.deleteObject(deleteObjectRequest);
-            log.info("✅ 파일 삭제 성공: s3Key={}", s3Key);
+            log.info("파일 삭제 성공: s3Key={}", s3Key);
 
         } catch (Exception e) {
-            log.error("❌ 파일 삭제 실패: s3Key={}, error={}", s3Key, e.getMessage(), e);
+            log.error("파일 삭제 실패: s3Key={}, error={}", s3Key, e.getMessage(), e);
             throw new FileUploadException(ErrorCode.FILE_DELETE_FAILED);
         }
     }
@@ -157,11 +162,11 @@ public class FileStorageService {
                 successCount++;
             } catch (Exception e) {
                 failCount++;
-                log.error("❌ 파일 삭제 중 오류 발생: s3Key={}", key);
+                log.error("파일 삭제 중 오류 발생: s3Key={}", key);
             }
         }
 
-        log.info("✅ 다중 파일 삭제 완료: totalFiles={}, successCount={}, failCount={}",
+        log.info("다중 파일 삭제 완료: totalFiles={}, successCount={}, failCount={}",
                 s3Keys.size(), successCount, failCount);
     }
 
@@ -173,31 +178,31 @@ public class FileStorageService {
         log.debug("파일 유효성 검증 시작: fileName={}", file.getOriginalFilename());
 
         if (file.isEmpty()) {
-            log.error("❌ 빈 파일: fileName={}", file.getOriginalFilename());
+            log.error("빈 파일: fileName={}", file.getOriginalFilename());
             throw new FileUploadException(ErrorCode.EMPTY_FILE);
         }
 
         String originalFileName = file.getOriginalFilename();
         if (originalFileName == null || originalFileName.isEmpty()) {
-            log.error("❌ 잘못된 파일명: fileName=null or empty");
+            log.error("잘못된 파일명: fileName=null or empty");
             throw new FileUploadException(ErrorCode.INVALID_FILE_NAME);
         }
 
         String extension = getFileExtension(originalFileName).toLowerCase();
         if (!ALLOWED_EXTENSIONS.contains(extension)) {
-            log.error("❌ 허용되지 않은 확장자: fileName={}, extension={}, allowedExtensions={}",
+            log.error("허용되지 않은 확장자: fileName={}, extension={}, allowedExtensions={}",
                     originalFileName, extension, ALLOWED_EXTENSIONS);
             throw new FileUploadException(ErrorCode.INVALID_FILE_TYPE);
         }
 
         long maxSize = 10 * 1024 * 1024;
         if (file.getSize() > maxSize) {
-            log.error("❌ 파일 크기 초과: fileName={}, size={} bytes, maxSize={} bytes",
+            log.error("파일 크기 초과: fileName={}, size={} bytes, maxSize={} bytes",
                     originalFileName, file.getSize(), maxSize);
             throw new FileUploadException(ErrorCode.FILE_SIZE_EXCEEDED);
         }
 
-        log.debug("✅ 파일 유효성 검증 통과: fileName={}, extension={}, size={} bytes",
+        log.debug("파일 유효성 검증 통과: fileName={}, extension={}, size={} bytes",
                 originalFileName, extension, file.getSize());
     }
 
@@ -221,7 +226,7 @@ public class FileStorageService {
     private String getFileExtension(String fileName) {
         int lastDotIndex = fileName.lastIndexOf(".");
         if (lastDotIndex == -1) {
-            log.error("❌ 확장자 없음: fileName={}", fileName);
+            log.error("확장자 없음: fileName={}", fileName);
             throw new FileUploadException(ErrorCode.INVALID_FILE_NAME);
         }
         return fileName.substring(lastDotIndex + 1);

--- a/src/main/java/project/food/global/file/service/LocalFileStorage.java
+++ b/src/main/java/project/food/global/file/service/LocalFileStorage.java
@@ -1,0 +1,142 @@
+package project.food.global.file.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import project.food.global.config.FileStorageConfig;
+import project.food.global.exception.ErrorCode;
+import project.food.global.exception.FileUploadException;
+import project.food.global.file.dto.UploadedFileInfo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Profile({"dev", "test"})
+@RequiredArgsConstructor
+@Slf4j
+public class LocalFileStorage implements FileStorage {
+
+    private final FileStorageConfig fileStorageConfig;
+
+    private static final String BASE_DIR = "uploads";
+    private static final String BASE_URL = "http://localhost:8080/uploads";
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "gif", "webp");
+
+    private UploadedFileInfo storeFile(MultipartFile file, String subDir, Long memberId) {
+        validateFile(file);
+
+        String originalFileName = file.getOriginalFilename();
+        String storedFileName = generateStoredFileName(originalFileName);
+        Path dirPath = Paths.get(BASE_DIR, subDir, String.valueOf(memberId));
+        Path filePath = dirPath.resolve(storedFileName);
+
+        try {
+            Files.createDirectories(dirPath);
+            file.transferTo(filePath.toAbsolutePath());
+
+            String relativePath = subDir + "/" + memberId + "/" + storedFileName;
+            String fileUrl = BASE_URL + "/" + relativePath;
+
+            log.info("로컬 파일 저장: {}", filePath);
+
+            return UploadedFileInfo.builder()
+                    .originalFileName(originalFileName)
+                    .storedFileName(storedFileName)
+                    .filePath(relativePath)
+                    .fileSize(file.getSize())
+                    .fileUrl(fileUrl)
+                    .build();
+
+        } catch (IOException e) {
+            throw new FileUploadException(ErrorCode.FILE_UPLOAD_FAILED, "파일 저장 중 오류: " + originalFileName);
+        }
+    }
+
+    @Override
+    public UploadedFileInfo savePostImage(MultipartFile file, Long memberId) {
+        return storeFile(file, "post", memberId);
+    }
+
+    @Override
+    public UploadedFileInfo saveProfileImage(MultipartFile file, Long memberId) {
+        return storeFile(file, "profile", memberId);
+    }
+
+    @Override
+    public List<UploadedFileInfo> storeFiles(List<MultipartFile> files, Long memberId) {
+        log.info("다중 파일 저장 시작: memberId={}, fileCount={}", memberId, files.size());
+
+        if (files.size() > fileStorageConfig.getMaxFileCount()) {
+            throw new FileUploadException(ErrorCode.FILE_COUNT_EXCEEDED);
+        }
+
+        List<UploadedFileInfo> uploadedFiles = new ArrayList<>();
+        for (MultipartFile file : files) {
+            if (!file.isEmpty()) {
+                uploadedFiles.add(savePostImage(file, memberId));
+            }
+        }
+
+        log.info("다중 파일 저장 완료: memberId={}, savedCount={}", memberId, uploadedFiles.size());
+        return uploadedFiles;
+    }
+
+    @Override
+    public void deleteFile(String path) {
+        try {
+            Path filePath = Paths.get(BASE_DIR).resolve(path);
+            Files.deleteIfExists(filePath);
+            log.info("로컬 파일 삭제: {}", filePath);
+        } catch (IOException e) {
+            log.error("로컬 파일 삭제 실패: {}", path, e);
+            throw new FileUploadException(ErrorCode.FILE_DELETE_FAILED);
+        }
+    }
+
+    @Override
+    public void deleteFiles(List<String> paths) {
+        paths.forEach(path -> {
+            try {
+                deleteFile(path);
+            } catch (Exception e) {
+                log.error("로컬 파일 삭제 중 오류: {}", path);
+            }
+        });
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file.isEmpty()) throw new FileUploadException(ErrorCode.EMPTY_FILE);
+
+        String originalFileName = file.getOriginalFilename();
+        if (originalFileName == null || originalFileName.isEmpty()) {
+            throw new FileUploadException(ErrorCode.INVALID_FILE_NAME);
+        }
+
+        String extension = getFileExtension(originalFileName).toLowerCase();
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new FileUploadException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        if (file.getSize() > 10 * 1024 * 1024) {
+            throw new FileUploadException(ErrorCode.FILE_SIZE_EXCEEDED);
+        }
+    }
+
+    private String generateStoredFileName(String originalFileName) {
+        return UUID.randomUUID() + "." + getFileExtension(originalFileName);
+    }
+
+    private String getFileExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf(".");
+        if (lastDotIndex == -1) throw new FileUploadException(ErrorCode.INVALID_FILE_NAME);
+        return fileName.substring(lastDotIndex + 1);
+    }
+}

--- a/src/main/java/project/food/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/project/food/global/jwt/JwtAuthenticationFilter.java
@@ -32,13 +32,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
             Long memberId = jwtTokenProvider.getMemberIdFromToken(token);
+            String role = jwtTokenProvider.getRoleFromToken(token);
+
+            String authority = (role != null) ? role : "ROLE_USER";
 
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(memberId, null,
-                            List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                            List.of(new SimpleGrantedAuthority(authority)));
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
-            log.debug("인증 완료: memberId = {}", memberId);
+            log.debug("인증 완료: memberId = {}, role = {}", memberId, authority);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/project/food/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/project/food/global/jwt/JwtTokenProvider.java
@@ -31,8 +31,8 @@ public class JwtTokenProvider {
         return createToken(memberId, email, role, accessTokenExpiration);
     }
 
-    public String createRefreshToken(Long memberId) {
-        return createToken(memberId, null, null, refreshTokenExpiration);
+    public String createRefreshToken(Long memberId, String role) {
+        return createToken(memberId, null, role, refreshTokenExpiration);
     }
 
     private String createToken(Long memberId, String email, String role, long expiration) {
@@ -57,6 +57,11 @@ public class JwtTokenProvider {
     public Long getMemberIdFromToken(String token) {
         Claims claims = parseClaims(token);
         return Long.parseLong(claims.getSubject());
+    }
+
+    public String getRoleFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("role", String.class);
     }
 
     public boolean validateToken(String token) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,11 +2,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-        default_batch_fetch_size: 100
   cache:
     type: none
 
@@ -23,7 +21,5 @@ logging:
     project.food: DEBUG
     org.springframework.web: DEBUG
     org.hibernate: INFO
-
-admin:
-  email: admin@food.com
-  password: admin1234
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,12 +13,10 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: false
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-        default_batch_fetch_size: 100
         query.in_clause_parameter_padding: true
 
   cache:
@@ -26,12 +24,26 @@ spring:
     caffeine:
       spec: maximumSize=1000,expireAfterWrite=600s
 
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+      s3:
+        bucket: ${AWS_S3_BUCKET}
+      region:
+        static: ${AWS_REGION}
+
 kakao:
   api:
     key: ${KAKAO_API_KEY}
 
 jwt:
   secret: ${JWT_SECRET}
+
+admin:
+  email: ${ADMIN_EMAIL}
+  password: ${ADMIN_PASSWORD}
 
 server:
   port: 8080
@@ -48,6 +60,9 @@ server:
       min-spare: 10
     max-connections: 8192
     accept-count: 100
+
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   application:
     name: Food
-  profiles: { include: secret, active: dev }
+  profiles: { include: secret }
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}
@@ -13,6 +13,7 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
+        default_batch_fetch_size: 100
   servlet:
     multipart:
       enabled: true               # 파일 업로드 활성화
@@ -22,15 +23,12 @@ spring:
 
 file:
   upload:
-    dir: ./uploads    # 파일 저장 경로 (프로제트 루트 기준)
     max-file-count: 10      # 게시글당 최대 파일 개수
 
 logging:
   level:
     root: INFO
     project.food: INFO
-    org.hibernate.SQL: DEBUG
-    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} %-5level - %msg%n"
 


### PR DESCRIPTION
## 개요

포트폴리오 점검 과정에서 발견된 보안 취약점, 성능 문제, 검증 누락을 전반적으로 수정합니다.

## 변경 사항

### 🔐 보안
- `SecurityConfig`: `GET /api/members` permitAll 충돌 수정 — POST(회원가입)만 허용, GET(목록)은 ADMIN 전용으로 분리
- `SecurityConfig`: 좋아요 목록 조회 엔드포인트(`/api/posts/likes/member/**`, `/api/comments/likes/member/**`) 인증 필요로 변경
- `MemberController/Service`: `updateMember`, `updatePassword`에 소유권 검사 추가 — 본인 또는 어드민만 수정 가능
- `JwtTokenProvider`: `refreshToken`에 role 클레임 포함 — 토큰 갱신 시 ADMIN 권한이 ROLE_USER로 초기화되던 버그 수정

### ⚡ 성능
- `Post`, `Comment` 엔티티: FK 컬럼(`member_id`, `restaurant_id`, `post_id`, `parent_comment_id`)에 인덱스 추가
- `MemberService.deleteMember`: 루프 N*M 쿼리 → `IN`절 배치 삭제로 최적화 (쿼리 수 고정)
- `PostRepository`: 미사용 메서드 `findByMemberIdWithComments` 제거

### ✅ 검증
- `PostController`: `createPost`, `updatePost`에 `@Valid` 추가
- `PostUpdateDto`: `title`, `content`에 `@NotBlank` 추가
- `PostController/Service`: `getPostsByMember`, `searchPosts` 페이지네이션 적용 (`List` → `Page`)

### ⚙️ 설정
- `WebConfig`: CORS allowed-origins 하드코딩 제거 → `@Value` 주입으로 환경별 분리
- `application.yml` / `application-prod.yml`: `cors.allowed-origins` 환경별 분리 (`prod`는 `${CORS_ALLOWED_ORIGINS}` 환경변수 참조)
- `deploy.yml`: `CORS_ALLOWED_ORIGINS` 환경변수 주입 추가

### 🗂️ 파일 스토리지
- `FileStorage` 인터페이스 추가 — dev/prod 구현체 분리
- `LocalFileStorage` 추가 — dev/test 환경에서 로컬 파일시스템에 `uploads/{type}/{memberId}/` 구조로 저장
- `S3Config`, `FileStorageService`에 `@Profile("prod")` 적용

### 🧹 기타
- 로그 이모지 전체 제거 (✅ ❌ ⚠️ ⭐)

## 주의사항

> prod DB에 아래 인덱스 SQL을 직접 실행해야 합니다 (`ddl-auto: validate`로 자동 생성 안 됨)

```sql
CREATE INDEX idx_post_member_id     ON post(member_id);
CREATE INDEX idx_post_restaurant_id ON post(restaurant_id);
CREATE INDEX idx_post_created_at    ON post(created_at);
CREATE INDEX idx_comment_post_id    ON comments(post_id);
CREATE INDEX idx_comment_member_id  ON comments(member_id);
CREATE INDEX idx_comment_parent_id  ON comments(parent_comment_id);
```