### PR TITLE
fix: application-test.yml 하드코딩된 admin 계정 정보 제거

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -29,8 +29,8 @@ server:
     include-binding-errors: always
 
 admin:
-  email: admin@test.com
-  password: test1234!
+  email:
+  password:
 
 
 logging:


### PR DESCRIPTION
## Summary
- 테스트 설정 파일(`application-test.yml`)에 하드코딩된 admin 이메일/비밀번호 노출 제거
- `admin.email`, `admin.password` 값을 빈 값으로 변경

## Test plan
- [ ] 기존 테스트 정상 통과 확인
- [ ] CI/CD 파이프라인 통과 확인
