### PR TITLE
fix: application-test.yml CI 테스트 환경변수 기본값 추가

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -15,12 +15,12 @@ spring:
   cloud:
     aws:
           credentials:
-            access-key: test-access-key
-            secret-key: test-secret-key
+            access-key: ${spring.cloud.aws.credentials.access-key:test-access-key}
+            secret-key: ${spring.cloud.aws.credentials.secret-key:test-secret-key}
           s3:
-            bucket: test-bucket
+            bucket: ${spring.cloud.aws.s3.bucket:test-bucket}
           region:
-            static: ap-northeast-2
+            static: ${spring.cloud.aws.region.static:ap-northeast-2}
 
 server:
   port: 8081
@@ -28,9 +28,19 @@ server:
     include-message: always
     include-binding-errors: always
 
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5500}
+
+kakao:
+  api:
+    key: ${kakao.api.key:test-kakao-key}
+
+jwt:
+  secret: ${jwt.secret:test-secret-key-for-jwt-must-be-at-least-32-characters}
+
 admin:
-  email:
-  password:
+  email: ${admin.email:admin@test.com}
+  password: ${admin.password:test1234!}
 
 
 logging:


### PR DESCRIPTION
## Summary
- CI에서 `./gradlew build` 실행 시 `application-test.yml`의 `${...}` 플레이스홀더에 값이 없어 `PropertyPlaceholderHelper` 에러 발생
- `${property:default}` 문법으로 테스트용 더미 기본값 추가
- 실제 환경변수가 있으면 그 값을 사용하고, 없으면 더미값으로 fallback

## Test plan
- [ ] CI `FoodApplicationTests > contextLoads()` 통과 확인
- [ ] 전체 테스트 21개 통과 확인
