### PR TITLE
fix: application-test.yml 순환 참조 및 AWS 자동 설정 에러 수정

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -14,13 +14,15 @@ spring:
         format_sql: true
   cloud:
     aws:
-          credentials:
-            access-key: ${spring.cloud.aws.credentials.access-key:test-access-key}
-            secret-key: ${spring.cloud.aws.credentials.secret-key:test-secret-key}
-          s3:
-            bucket: ${spring.cloud.aws.s3.bucket:test-bucket}
-          region:
-            static: ${spring.cloud.aws.region.static:ap-northeast-2}
+      credentials:
+        access-key: test-access-key
+        secret-key: test-secret-key
+      s3:
+        bucket: test-bucket
+      region:
+        static: ap-northeast-2
+      stack:
+        auto: false
 
 server:
   port: 8081
@@ -29,18 +31,18 @@ server:
     include-binding-errors: always
 
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5500}
+  allowed-origins: http://localhost:5500
 
 kakao:
   api:
-    key: ${kakao.api.key:test-kakao-key}
+    key: test-kakao-key
 
 jwt:
-  secret: ${jwt.secret:test-secret-key-for-jwt-must-be-at-least-32-characters}
+  secret: test-secret-key-for-jwt-must-be-at-least-32-characters
 
 admin:
-  email: ${admin.email:admin@test.com}
-  password: ${admin.password:test1234!}
+  email: admin@test.com
+  password: test1234!
 
 
 logging:


### PR DESCRIPTION
## Summary
- `${jwt.secret:fallback}` 처럼 자기 자신을 참조하는 순환 참조 플레이스홀더 → 직접 더미값으로 교체
- `spring.cloud.aws.credentials.access-key` 등 AWS 관련 자기 참조 플레이스홀더 → 직접 더미값으로 교체
- `spring.cloud.aws.stack.auto: false` 추가 → 테스트 시 AWS 연결 시도 방지

## 원인
테스트 환경에서 `${jwt.secret:fallback}` 형태는 `jwt.secret` 프로퍼티가 자기 자신을 참조해 순환 참조 에러 발생
테스트 파일에서는 `${...}` 없이 직접 더미값을 써야 함

## Test plan
- [x] `./gradlew test` 전체 통과 확인
- [ ] CI/CD 파이프라인 통과 확인
