### PR TITLE
fix: Dockerfile jar 경로 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse-temurin:17-jre
 WORKDIR /app
-COPY *.jar app.jar
+COPY build/libs/*-SNAPSHOT.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary
- `COPY *.jar app.jar` → `COPY build/libs/*-SNAPSHOT.jar app.jar`
- Gradle 빌드 결과물이 `build/libs/`에 생성되므로 경로 수정
- 기존 경로로 인해 컨테이너 시작 시 `Error: Unable to access jarfile app.jar` 발생

## Test plan
- [ ] CI/CD 배포 후 컨테이너 정상 실행 확인
