### PR TITLE
fix: Docker 빌드 시 jar 파일 복사 단계 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,9 @@ jobs:
           distribution: 'temurin'
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: |
+          ./gradlew build
+          cp build/libs/*-SNAPSHOT.jar app.jar
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse-temurin:17-jre
 WORKDIR /app
-COPY build/libs/*-SNAPSHOT.jar app.jar
+COPY *.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary
- `.dockerignore`에서 `build/` 디렉토리가 제외되어 있어 Docker가 jar를 찾지 못하는 문제 수정
- Gradle 빌드 후 `cp build/libs/*-SNAPSHOT.jar app.jar`로 루트에 복사한 뒤 Docker 이미지 빌드
- Dockerfile `COPY *.jar app.jar`는 루트의 jar를 복사

## Test plan
- [ ] CI/CD 배포 후 컨테이너 정상 실행 확인
