### PR TITLE
fix: 게시글 삭제 시 댓글 좋아요 FK 제약 에러 수정

### DIFF
--- a/src/main/java/project/food/domain/like/commentlike/repository/CommentLikeRepository.java
+++ b/src/main/java/project/food/domain/like/commentlike/repository/CommentLikeRepository.java
@@ -75,6 +75,14 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
     void deleteByCommentId(Long commentId);
 
     /**
+     * 특정 게시글에 달린 댓글의 좋아요 일괄 삭제 (게시글 삭제 시 사용)
+     * @param postId 게시글 ID
+     */
+    @Modifying
+    @Query("DELETE FROM CommentLike cl WHERE cl.comment.post.id = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
+
+    /**
      * 여러 게시글에 달린 댓글의 좋아요 일괄 삭제 (회원 탈퇴 시 사용)
      * @param postIds 게시글 ID 목록
      */

--- a/src/main/java/project/food/domain/post/service/PostService.java
+++ b/src/main/java/project/food/domain/post/service/PostService.java
@@ -21,6 +21,7 @@ import project.food.domain.restaurant.repository.RestaurantRepository;
 import project.food.domain.tag.entity.PostTag;
 import project.food.domain.tag.entity.Tag;
 import project.food.domain.tag.repository.TagRepository;
+import project.food.domain.like.commentlike.repository.CommentLikeRepository;
 import project.food.domain.like.postlike.repository.PostLikeRepository;
 import project.food.global.exception.CustomException;
 import project.food.global.exception.ErrorCode;
@@ -49,6 +50,7 @@ public class PostService {
     private final RestaurantRepository restaurantRepository;
     private final TagRepository tagRepository;
     private final PostLikeRepository postLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
 
     /**
      * 게시글 생성
@@ -314,9 +316,10 @@ public class PostService {
             log.debug("게시글 이미지 파일 삭제 완료: postId={}", postId);
         }
 
-        postLikeRepository.deleteByPostId(postId);
+        commentLikeRepository.deleteByPostId(postId);  // 댓글 좋아요 먼저 삭제
+        postLikeRepository.deleteByPostId(postId);      // 게시글 좋아요 삭제
 
-        postRepository.delete(post);
+        postRepository.delete(post);  // 게시글 삭제 (댓글 cascade 삭제)
 
         log.info("게시글 삭제 완료: postId={}, memberId={}, deletedImages={}",
                 postId, memberId, filePaths.size());


### PR DESCRIPTION
## Summary
- 게시글 삭제 시 `comment_like` FK 제약 위반으로 500 에러 발생 수정
- 삭제 순서: 댓글 좋아요 → 게시글 좋아요 → 게시글(댓글 cascade 삭제)
- `CommentLikeRepository`에 `deleteByPostId` 메서드 추가

## 원인
```
기존: 게시글 좋아요 삭제 → 게시글 삭제 시도
     → 댓글 삭제 시도 → comment_like가 아직 있음 → FK 에러
수정: 댓글 좋아요 먼저 삭제 → 게시글 좋아요 삭제 → 게시글 삭제
```

## Test plan
- [ ] 댓글/좋아요가 있는 게시글 삭제 정상 동작 확인