### PR TITLE
feat: 네이버 이미지 API로 맛집 대표 이미지 자동 저장

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,4 +77,6 @@ jobs:
               -e ADMIN_PASSWORD=${{ secrets.ADMIN_PASSWORD }} \
               -e SPRING_CLOUD_AWS_S3_BUCKET=${{ secrets.AWS_S3_BUCKET }} \
               -e CORS_ALLOWED_ORIGINS="${{ secrets.CORS_ALLOWED_ORIGINS }}" \
+              -e NAVER_API_CLIENT_ID=${{ secrets.NAVER_API_CLIENT_ID }} \
+              -e NAVER_API_CLIENT_SECRET=${{ secrets.NAVER_API_CLIENT_SECRET }} \
               ${{ secrets.ECR_REPOSITORY }}:latest

--- a/src/main/java/project/food/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/project/food/domain/restaurant/entity/Restaurant.java
@@ -57,4 +57,12 @@ public class Restaurant extends BaseTimeEntity {
     // 카카오 플레이스 URL
     @Column(name = "place_url", length = 500)
     private String placeUrl;
+
+    // 네이버 검색으로 가져온 대표 이미지 S3 URL
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/project/food/global/api/naver/NaverSearchService.java
+++ b/src/main/java/project/food/global/api/naver/NaverSearchService.java
@@ -1,0 +1,95 @@
+package project.food.global.api.naver;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NaverSearchService {
+
+    @Value("${naver.api.client-id}")
+    private String clientId;
+
+    @Value("${naver.api.client-secret}")
+    private String clientSecret;
+
+    private static final String NAVER_IMAGE_SEARCH_URL = "https://openapi.naver.com/v1/search/image";
+
+    private final RestTemplate restTemplate;
+
+    /**
+     * 음식점 이름으로 네이버 이미지 검색 후 첫 번째 이미지 byte[] 반환
+     * 이미지가 없거나 실패하면 null 반환 (실패해도 맛집 저장은 계속 진행)
+     */
+    public byte[] searchRestaurantImage(String restaurantName) {
+        log.debug("[NAVER][IMAGE] 이미지 검색 시작: query={}", restaurantName);
+
+        try {
+            URI uri = UriComponentsBuilder
+                    .fromHttpUrl(NAVER_IMAGE_SEARCH_URL)
+                    .queryParam("query", restaurantName)
+                    .queryParam("display", 1)   // 첫 번째 이미지만
+                    .queryParam("sort", "sim")  // 유사도순
+                    .encode(StandardCharsets.UTF_8)
+                    .build()
+                    .toUri();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-Naver-Client-Id", clientId);
+            headers.set("X-Naver-Client-Secret", clientSecret);
+
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    uri, HttpMethod.GET, entity, Map.class);
+
+            Map body = response.getBody();
+            if (body == null) return null;
+
+            List<Map> items = (List<Map>) body.get("items");
+            if (items == null || items.isEmpty()) {
+                log.warn("[NAVER][IMAGE] 검색 결과 없음: query={}", restaurantName);
+                return null;
+            }
+
+            // thumbnail: 작은 미리보기 / link: 원본 이미지
+            String imageUrl = (String) items.get(0).get("thumbnail");
+            if (imageUrl == null) return null;
+
+            log.debug("[NAVER][IMAGE] 이미지 URL 획득: query={}, url={}", restaurantName, imageUrl);
+
+            // 이미지 다운로드
+            return downloadImage(imageUrl);
+
+        } catch (Exception e) {
+            log.warn("[NAVER][IMAGE] 이미지 검색 실패 (스킵): query={}, error={}", restaurantName, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 이미지 URL로 byte[] 다운로드
+     */
+    private byte[] downloadImage(String imageUrl) {
+        try {
+            ResponseEntity<byte[]> response = restTemplate.getForEntity(imageUrl, byte[].class);
+            log.debug("[NAVER][IMAGE] 이미지 다운로드 완료: size={} bytes",
+                    response.getBody() != null ? response.getBody().length : 0);
+            return response.getBody();
+        } catch (Exception e) {
+            log.warn("[NAVER][IMAGE] 이미지 다운로드 실패 (스킵): url={}, error={}", imageUrl, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/project/food/global/config/DataInitializer.java
+++ b/src/main/java/project/food/global/config/DataInitializer.java
@@ -10,7 +10,15 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import project.food.domain.member.entity.Member;
 import project.food.domain.member.repository.MemberRepository;
+import project.food.domain.restaurant.entity.Restaurant;
+import project.food.domain.restaurant.repository.RestaurantRepository;
+import project.food.global.api.kakao.local.dto.KakaoKeywordResponse;
+import project.food.global.api.kakao.local.service.KakaoLocalService;
+import project.food.global.api.naver.NaverSearchService;
 import project.food.global.enums.Role;
+import project.food.global.file.service.FileStorage;
+
+import java.util.List;
 
 @Slf4j
 @Configuration
@@ -19,12 +27,21 @@ public class DataInitializer {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RestaurantRepository restaurantRepository;
+    private final KakaoLocalService kakaoLocalService;
+    private final NaverSearchService naverSearchService;
+    private final FileStorage fileStorage;
 
     @Value("${admin.email}")
     private String adminEmail;
 
     @Value("${admin.password}")
     private String adminPassword;
+
+    // 초기 맛집 검색 키워드 목록
+    private static final List<String> INIT_KEYWORDS = List.of(
+            "강남 맛집", "홍대 맛집", "이태원 맛집", "신촌 맛집", "건대 맛집"
+    );
 
     @Bean
     @Profile({"dev", "prod"})
@@ -34,8 +51,8 @@ public class DataInitializer {
             log.info("===== 초기 데이터 생성 시작 =====");
             log.info("============================");
 
-            // 관리자 계정 생성
             createAdminIfNotExists();
+            initRestaurantsIfEmpty();
 
             log.info("============================");
             log.info("===== 초기 데이터 생성 완료 =====");
@@ -48,15 +65,12 @@ public class DataInitializer {
      * 이미 존재하는 경우 생성하지 않음
      */
     private void createAdminIfNotExists() {
-
         if (memberRepository.existsByEmail(adminEmail)) {
             log.info("관리자 계정이 이미 존재합니다: {}", adminEmail);
             return;
         }
 
-        // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(adminPassword);
-
         Member admin = Member.builder()
                 .email(adminEmail)
                 .password(encodedPassword)
@@ -69,5 +83,112 @@ public class DataInitializer {
         log.info("관리자 계정 생성 완료");
         log.info(" - 이메일: {}", adminEmail);
         log.info(" - 권한: ADMIN");
+    }
+
+    /**
+     * 맛집 초기 데이터 생성
+     * DB가 비어있을 때만 실행 → 서버 재시작마다 카카오/네이버 API 호출 방지
+     */
+    private void initRestaurantsIfEmpty() {
+        if (restaurantRepository.count() > 0) {
+            log.info("맛집 데이터가 이미 존재합니다. 초기화 스킵");
+            return;
+        }
+
+        log.info("맛집 초기 데이터 생성 시작: keywords={}", INIT_KEYWORDS);
+        int totalSaved = 0;
+
+        for (String keyword : INIT_KEYWORDS) {
+            try {
+                totalSaved += saveRestaurantsByKeyword(keyword);
+            } catch (Exception e) {
+                // 키워드 하나 실패해도 나머지 계속 진행
+                log.warn("키워드 초기화 실패 (스킵): keyword={}, error={}", keyword, e.getMessage());
+            }
+        }
+
+        log.info("맛집 초기 데이터 생성 완료: 총 {}개 저장", totalSaved);
+    }
+
+    /**
+     * 키워드로 카카오 검색 → 맛집 저장 → 네이버로 이미지 저장
+     */
+    private int saveRestaurantsByKeyword(String keyword) {
+        log.debug("키워드 맛집 검색 시작: keyword={}", keyword);
+
+        KakaoKeywordResponse response = kakaoLocalService.searchPlaceByKeyword(keyword, 1);
+        if (!response.hasResult()) {
+            log.warn("카카오 검색 결과 없음: keyword={}", keyword);
+            return 0;
+        }
+
+        int savedCount = 0;
+
+        for (KakaoKeywordResponse.Place place : response.getDocuments()) {
+            try {
+                // 이미 저장된 맛집이면 스킵 (sourceId로 중복 체크)
+                if (restaurantRepository.existsBySourceId(place.getId())) {
+                    log.debug("이미 존재하는 맛집 스킵: sourceId={}", place.getId());
+                    continue;
+                }
+
+                // 주소는 도로명 우선, 없으면 지번 사용
+                String address = place.getRoadAddressName() != null && !place.getRoadAddressName().isEmpty()
+                        ? place.getRoadAddressName()
+                        : place.getAddressName();
+
+                Restaurant restaurant = Restaurant.builder()
+                        .sourceId(place.getId())
+                        .name(place.getPlaceName())
+                        .address(address)
+                        .category(place.getCategoryName())
+                        .latitude(parseDouble(place.getY()))
+                        .longitude(parseDouble(place.getX()))
+                        .placeUrl(place.getPlaceUrl())
+                        .build();
+
+                Restaurant saved = restaurantRepository.save(restaurant);
+
+                // 네이버로 이미지 검색 → S3 저장
+                saveRestaurantImage(saved, place.getPlaceName());
+
+                savedCount++;
+                log.debug("맛집 저장: name={}, sourceId={}", place.getPlaceName(), place.getId());
+
+            } catch (Exception e) {
+                log.warn("맛집 저장 실패 (스킵): name={}, error={}", place.getPlaceName(), e.getMessage());
+            }
+        }
+
+        log.info("키워드 맛집 저장 완료: keyword={}, savedCount={}", keyword, savedCount);
+        return savedCount;
+    }
+
+    /**
+     * 네이버 이미지 검색 → 다운로드 → S3 저장 → Restaurant.imageUrl 업데이트
+     * 실패해도 맛집 저장 자체는 유지됨
+     */
+    private void saveRestaurantImage(Restaurant restaurant, String restaurantName) {
+        try {
+            byte[] imageBytes = naverSearchService.searchRestaurantImage(restaurantName);
+            if (imageBytes == null) return;
+
+            String s3Url = fileStorage.saveRestaurantImage(imageBytes, restaurantName + ".jpg");
+            restaurant.updateImageUrl(s3Url);
+            restaurantRepository.save(restaurant);
+
+            log.debug("맛집 이미지 저장 완료: name={}, url={}", restaurantName, s3Url);
+        } catch (Exception e) {
+            log.warn("맛집 이미지 저장 실패 (스킵): name={}, error={}", restaurantName, e.getMessage());
+        }
+    }
+
+    private Double parseDouble(String value) {
+        if (value == null || value.isEmpty()) return null;
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/project/food/global/file/service/FileStorage.java
+++ b/src/main/java/project/food/global/file/service/FileStorage.java
@@ -11,4 +11,6 @@ public interface FileStorage {
     List<UploadedFileInfo> storeFiles(List<MultipartFile> files, Long memberId);
     void deleteFile(String path);
     void deleteFiles(List<String> paths);
+    // 네이버에서 다운로드한 이미지(byte[])를 저장 후 URL 반환
+    String saveRestaurantImage(byte[] imageBytes, String fileName);
 }

--- a/src/main/java/project/food/global/file/service/FileStorageService.java
+++ b/src/main/java/project/food/global/file/service/FileStorageService.java
@@ -121,6 +121,28 @@ public class FileStorageService implements FileStorage {
     }
 
     /**
+     * byte[] 이미지를 S3 restaurant/ 경로에 저장 후 URL 반환
+     * 네이버에서 다운로드한 이미지 저장에 사용
+     */
+    @Override
+    public String saveRestaurantImage(byte[] imageBytes, String fileName) {
+        String s3Key = "restaurant/" + UUID.randomUUID() + "_" + fileName;
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(s3Key)
+                    .contentType("image/jpeg")
+                    .contentLength((long) imageBytes.length)
+                    .build();
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(imageBytes));
+            return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + s3Key;
+        } catch (Exception e) {
+            log.error("맛집 이미지 S3 저장 실패: fileName={}, error={}", fileName, e.getMessage());
+            throw new FileUploadException(ErrorCode.FILE_UPLOAD_FAILED, "맛집 이미지 저장 실패: " + fileName);
+        }
+    }
+
+    /**
      * 파일 삭제 (S3 key 또는 전체 S3 URL 전달)
      */
     public void deleteFile(String s3KeyOrUrl) {

--- a/src/main/java/project/food/global/file/service/LocalFileStorage.java
+++ b/src/main/java/project/food/global/file/service/LocalFileStorage.java
@@ -112,6 +112,22 @@ public class LocalFileStorage implements FileStorage {
         });
     }
 
+    @Override
+    public String saveRestaurantImage(byte[] imageBytes, String fileName) {
+        try {
+            String storedFileName = UUID.randomUUID() + "_" + fileName;
+            Path dirPath = Paths.get(BASE_DIR, "restaurant");
+            Files.createDirectories(dirPath);
+            Path filePath = dirPath.resolve(storedFileName);
+            Files.write(filePath, imageBytes);
+            log.info("맛집 이미지 로컬 저장: {}", filePath);
+            return BASE_URL + "/restaurant/" + storedFileName;
+        } catch (IOException e) {
+            log.error("맛집 이미지 로컬 저장 실패: {}", fileName);
+            throw new FileUploadException(ErrorCode.FILE_UPLOAD_FAILED, "맛집 이미지 저장 실패: " + fileName);
+        }
+    }
+
     private void validateFile(MultipartFile file) {
         if (file.isEmpty()) throw new FileUploadException(ErrorCode.EMPTY_FILE);
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -38,6 +38,11 @@ kakao:
   api:
     key: ${KAKAO_API_KEY}
 
+naver:
+  api:
+    client-id: ${NAVER_API_CLIENT_ID}
+    client-secret: ${NAVER_API_CLIENT_SECRET}
+
 jwt:
   secret: ${JWT_SECRET}
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -37,6 +37,11 @@ kakao:
   api:
     key: test-kakao-key
 
+naver:
+  api:
+    client-id: test-naver-client-id
+    client-secret: test-naver-client-secret
+
 jwt:
   secret: test-secret-key-for-jwt-must-be-at-least-32-characters
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,11 @@ management:
     health:
       show-details: when-authorized
 
+naver:
+  api:
+    client-id: ${naver.api.client-id}
+    client-secret: ${naver.api.client-secret}
+
 jwt:
   secret: ${jwt.secret}
   access-token-expiration: 1800000


### PR DESCRIPTION
## Summary
- 서버 시작 시 카카오 API로 맛집 검색 → 네이버 이미지 API로 대표 이미지 S3 저장
- `NaverSearchService`: 음식점명으로 네이버 이미지 검색 후 byte[] 다운로드
- `FileStorage.saveRestaurantImage()`: byte[]를 S3 `restaurant/` 경로에 업로드
- `Restaurant.imageUrl` 필드 추가
- `DataInitializer`: DB 비어있을 때만 키워드 5개 × 최대 15개 = 최대 75개 초기 맛집 저장
- 이미지 저장 실패해도 맛집 저장 자체는 유지 (에러 무시 처리)

## GitHub Secrets 추가 필요
- `NAVER_API_CLIENT_ID`
- `NAVER_API_CLIENT_SECRET`

## Test plan
- [ ] 서버 시작 시 맛집 75개 자동 저장 확인
- [ ] 각 맛집에 imageUrl 저장 확인
- [ ] CI/CD 배포 후 정상 동작 확인
