### PR TITLE
feat: Redis 캐싱/Refresh Token/좋아요·조회수 카운터 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,4 +79,6 @@ jobs:
               -e CORS_ALLOWED_ORIGINS="${{ secrets.CORS_ALLOWED_ORIGINS }}" \
               -e NAVER_API_CLIENT_ID=${{ secrets.NAVER_API_CLIENT_ID }} \
               -e NAVER_API_CLIENT_SECRET=${{ secrets.NAVER_API_CLIENT_SECRET }} \
+              -e REDIS_HOST=localhost \
+              --network host \
               ${{ secrets.ECR_REPOSITORY }}:latest

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ implementation 'org.springframework.boot:spring-boot-starter-validation'
     // AWS S3 (Spring Cloud AWS)
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,5 +10,12 @@ services:
       - mysql-data:/var/lib/mysql
     restart: always
 
+  redis:
+    image: redis:7-alpine
+    container_name: food-redis
+    ports:
+      - "6379:6379"
+    restart: always
+
 volumes:
   mysql-data:

--- a/src/main/java/project/food/FoodApplication.java
+++ b/src/main/java/project/food/FoodApplication.java
@@ -3,7 +3,9 @@ package project.food;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
 public class FoodApplication {
 

--- a/src/main/java/project/food/domain/like/postlike/service/PostLikeService.java
+++ b/src/main/java/project/food/domain/like/postlike/service/PostLikeService.java
@@ -14,6 +14,7 @@ import project.food.domain.like.postlike.entity.PostLike;
 import project.food.domain.like.postlike.repository.PostLikeRepository;
 import project.food.global.exception.CustomException;
 import project.food.global.exception.ErrorCode;
+import project.food.global.redis.PostCountService;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,6 +28,7 @@ public class PostLikeService {
     private final PostLikeRepository postLikeRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+    private final PostCountService postCountService;
 
     /**
      * 좋아요 추가
@@ -58,7 +60,8 @@ public class PostLikeService {
                 .build();
 
         PostLike savedLike = postLikeRepository.save(postLike);
-        
+        postCountService.incrementLikeCount(postId);  // Redis 카운터 증가
+
         log.info("좋아요 추가 완료: likeId = {}", savedLike.getId());
 
         return PostLikeResponseDto.simple(savedLike);
@@ -79,6 +82,7 @@ public class PostLikeService {
 
         // 좋아요 삭제
         postLikeRepository.delete(postLike);
+        postCountService.decrementLikeCount(postId);  // Redis 카운터 감소
 
         log.info("좋아요 취소 완료: likeId = {}", postLike.getId());
     }
@@ -120,8 +124,9 @@ public class PostLikeService {
             throw new CustomException(ErrorCode.POST_NOT_FOUND);
         }
 
-        // 좋아요 개수 조회
-        Long likeCount = postLikeRepository.countByPostId(postId);
+        // 좋아요 개수 조회 (Redis 우선, 없으면 DB에서 로드 후 Redis 초기화)
+        long dbLikeCount = postLikeRepository.countByPostId(postId);
+        Long likeCount = postCountService.getLikeCount(postId, dbLikeCount);
 
         // 사용자의 좋아요 여부 확인
         Boolean isLiked = false;

--- a/src/main/java/project/food/domain/member/controller/MemberController.java
+++ b/src/main/java/project/food/domain/member/controller/MemberController.java
@@ -84,6 +84,18 @@ public class MemberController {
     }
 
     /**
+     * 로그아웃
+     * POST /api/members/logout
+     */
+    @Operation(summary = "로그아웃", description = "Refresh Token을 무효화합니다.")
+    @ApiResponse(responseCode = "204", description = "로그아웃 성공")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal Long memberId) {
+        memberService.logout(memberId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
      * 전체 회원 목록 조회 (관리자 전용)
      * GET /api/members
      */

--- a/src/main/java/project/food/domain/member/service/MemberService.java
+++ b/src/main/java/project/food/domain/member/service/MemberService.java
@@ -17,6 +17,7 @@ import project.food.global.exception.ErrorCode;
 import project.food.global.file.dto.UploadedFileInfo;
 import project.food.global.file.service.FileStorage;
 import project.food.global.jwt.JwtTokenProvider;
+import project.food.global.jwt.RefreshTokenService;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,6 +37,7 @@ public class MemberService {
     private final CommentLikeRepository commentLikeRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
     private final FileStorage fileStorage;
 
     /**
@@ -96,6 +98,9 @@ public class MemberService {
                 member.getId(), member.getEmail(), member.getRole().getKey());
         String refreshToken = jwtTokenProvider.createRefreshToken(member.getId(), member.getRole().getKey());
 
+        // Redis에 Refresh Token 저장 (TTL = 7일)
+        refreshTokenService.save(member.getId(), refreshToken);
+
         log.info("로그인 성공: id = {}, email = {}", member.getId(), member.getEmail());
 
         return LoginResponseDto.builder()
@@ -116,11 +121,19 @@ public class MemberService {
         }
         Long memberId = jwtTokenProvider.getMemberIdFromToken(requestDto.getRefreshToken());
 
+        // Redis에 저장된 토큰과 일치하는지 검증 (탈취된 토큰 방어)
+        if (!refreshTokenService.isValid(memberId, requestDto.getRefreshToken())) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getEmail(), member.getRole().getKey());
 
         String refreshToken = jwtTokenProvider.createRefreshToken(memberId, member.getRole().getKey());
+
+        // 새 Refresh Token으로 Redis 갱신
+        refreshTokenService.save(memberId, refreshToken);
 
         log.info("토큰 재발급 완료 : memberId = {}", memberId);
 
@@ -129,6 +142,15 @@ public class MemberService {
                 .refreshToken(refreshToken)
                 .member(MemberResponseDto.from(member))
                 .build();
+    }
+
+    /**
+     * 로그아웃 - Redis에서 Refresh Token 삭제
+     */
+    @Transactional
+    public void logout(Long memberId) {
+        refreshTokenService.delete(memberId);
+        log.info("로그아웃 완료: memberId = {}", memberId);
     }
 
     /**

--- a/src/main/java/project/food/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/project/food/domain/post/dto/PostResponseDto.java
@@ -90,6 +90,25 @@ public class PostResponseDto {
                 .build();
     }
 
+    /** Redis 조회수로 덮어쓴 새 DTO 반환 */
+    public PostResponseDto withViewCount(int viewCount) {
+        return PostResponseDto.builder()
+                .id(this.id)
+                .memberId(this.memberId)
+                .memberNickname(this.memberNickname)
+                .title(this.title)
+                .content(this.content)
+                .rating(this.rating)
+                .ratingText(this.ratingText)
+                .viewCount(viewCount)
+                .images(this.images)
+                .tags(this.tags)
+                .restaurant(this.restaurant)
+                .createdAt(this.createdAt)
+                .updatedAt(this.updatedAt)
+                .build();
+    }
+
     @Schema(description = "이미지 정보")
     @Getter
     @NoArgsConstructor

--- a/src/main/java/project/food/domain/post/service/PostService.java
+++ b/src/main/java/project/food/domain/post/service/PostService.java
@@ -2,6 +2,9 @@ package project.food.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -26,7 +29,9 @@ import project.food.domain.like.postlike.repository.PostLikeRepository;
 import project.food.global.exception.CustomException;
 import project.food.global.exception.ErrorCode;
 import project.food.global.file.dto.UploadedFileInfo;
+import project.food.global.common.CachedPage;
 import project.food.global.file.service.FileStorage;
+import project.food.global.redis.PostCountService;
 
 import java.util.HashSet;
 import java.util.List;
@@ -51,6 +56,7 @@ public class PostService {
     private final TagRepository tagRepository;
     private final PostLikeRepository postLikeRepository;
     private final CommentLikeRepository commentLikeRepository;
+    private final PostCountService postCountService;
 
     /**
      * 게시글 생성
@@ -59,6 +65,11 @@ public class PostService {
      * @return 생성된 게시글 정보
      */
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = "posts", allEntries = true),
+            @CacheEvict(value = "restaurants-recommended", allEntries = true),
+            @CacheEvict(value = "restaurants-popular", allEntries = true)
+    })
     public PostResponseDto createPost(Long memberId, PostRequestDto request) {
 
         log.debug("게시글 생성 시작: memberId={}, title={}", memberId, request.getTitle());
@@ -131,7 +142,8 @@ public class PostService {
      * 게시글 전체 목록 조회 (최신순)
      * @return 게시글 목록
      */
-    public Page<PostResponseDto> getAllPosts(Pageable pageable) {
+    @Cacheable(value = "posts", key = "#pageable.pageNumber + '-' + #pageable.pageSize")
+    public CachedPage<PostResponseDto> getAllPosts(Pageable pageable) {
 
         log.debug("게시글 전체 목록 조회 시작");
 
@@ -140,7 +152,8 @@ public class PostService {
 
         log.info("게시글 전체 목록 조회 완료: totalCount={}", posts.getTotalElements());
 
-        return posts;
+        return new CachedPage<>(posts.getContent(), pageable.getPageNumber(),
+                pageable.getPageSize(), posts.getTotalElements());
     }
 
     /**
@@ -149,7 +162,6 @@ public class PostService {
      * @param postId 게시글 ID
      * @return 게시글 상세 정보
      */
-    @Transactional
     public PostResponseDto getPost(Long postId) {
 
         log.debug("게시글 상세 조회 시작: postId={}", postId);
@@ -160,16 +172,13 @@ public class PostService {
                     return new CustomException(ErrorCode.POST_NOT_FOUND);
                 });
 
-        int beforeViewCount = post.getViewCount();
-        post.increaseViewCount();
-
-        log.debug("조회수 증가: postId={}, {} → {}",
-                postId, beforeViewCount, post.getViewCount());
+        // 조회수 Redis INCR (DB UPDATE 없이 Redis에서 관리)
+        long viewCount = postCountService.incrementViewCount(postId);
 
         log.info("게시글 상세 조회 완료: postId={}, title={}, viewCount={}",
-                postId, post.getTitle(), post.getViewCount());
+                postId, post.getTitle(), viewCount);
 
-        return PostResponseDto.from(post);
+        return PostResponseDto.from(post).withViewCount((int) viewCount);
     }
 
     /**
@@ -180,6 +189,7 @@ public class PostService {
      * @return 수정된 게시글 정보
      */
     @Transactional
+    @CacheEvict(value = "posts", allEntries = true)
     public PostResponseDto updatePost(Long postId, Long memberId, PostUpdateDto request) {
 
         log.debug("게시글 수정 시작: postId={}, memberId={}", postId, memberId);
@@ -286,6 +296,11 @@ public class PostService {
      * @param memberId 삭제 요청자 ID
      */
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = "posts", allEntries = true),
+            @CacheEvict(value = "restaurants-recommended", allEntries = true),
+            @CacheEvict(value = "restaurants-popular", allEntries = true)
+    })
     public void deletePost(Long postId, Long memberId) {
 
         log.debug("게시글 삭제 시작: postId={}, memberId={}", postId, memberId);
@@ -320,6 +335,10 @@ public class PostService {
         postLikeRepository.deleteByPostId(postId);      // 게시글 좋아요 삭제
 
         postRepository.delete(post);  // 게시글 삭제 (댓글 cascade 삭제)
+
+        // Redis 카운터 제거
+        postCountService.deleteViewCount(postId);
+        postCountService.deleteLikeCount(postId);
 
         log.info("게시글 삭제 완료: postId={}, memberId={}, deletedImages={}",
                 postId, memberId, filePaths.size());

--- a/src/main/java/project/food/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/project/food/domain/restaurant/service/RestaurantService.java
@@ -2,7 +2,10 @@ package project.food.domain.restaurant.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.*;
+import project.food.global.common.CachedPage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.food.domain.post.repository.PostRepository;
@@ -45,15 +48,17 @@ public class RestaurantService {
      * @param size 페이지 크기
      * @return 맛집 목록 (간략 정보)
      */
-    public Page<RestaurantListItemResponse> search(String q, int page, int size) {
+    @Cacheable(value = "restaurants", key = "(#q ?: 'all') + '-' + #page + '-' + #size")
+    public CachedPage<RestaurantListItemResponse> search(String q, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
 
         // 검색어가 없으면 전체 조회, 있으면 이름/주소/카테고리 통합 검색
-        Page<Restaurant> result = (q == null || q.isBlank())
+        Page<RestaurantListItemResponse> result = ((q == null || q.isBlank())
                 ? restaurantRepository.findAll(pageable)
-                : restaurantRepository.search(q, pageable);
+                : restaurantRepository.search(q, pageable))
+                .map(RestaurantListItemResponse::from);
 
-        return result.map(RestaurantListItemResponse::from);
+        return new CachedPage<>(result.getContent(), page, size, result.getTotalElements());
     }
 
     /**
@@ -63,6 +68,7 @@ public class RestaurantService {
      * @param restaurantId 맛집 ID
      * @return 맛집 상세 정보 (리뷰 포함)
      */
+    @Cacheable(value = "restaurant", key = "#restaurantId")
     public RestaurantDetailResponse getDetail(Long restaurantId) {
         // 맛집 조회
         Restaurant restaurant = restaurantRepository.findById(restaurantId)
@@ -105,6 +111,7 @@ public class RestaurantService {
      * @param size   한 페이지 크기
      * @return cursor 페이지 응답
      */
+    @Cacheable(value = "restaurants-recommended", key = "(#cursor ?: 'first') + '-' + #size")
     public CursorPageResponse<RestaurantRankResponse> getRecommended(String cursor, int size) {
         List<Object[]> rows;
 
@@ -150,6 +157,7 @@ public class RestaurantService {
      * @param size   한 페이지 크기
      * @return cursor 페이지 응답
      */
+    @Cacheable(value = "restaurants-popular", key = "(#cursor ?: 'first') + '-' + #size")
     public CursorPageResponse<RestaurantRankResponse> getPopular(String cursor, int size) {
         List<Object[]> rows;
 

--- a/src/main/java/project/food/global/api/naver/NaverSearchService.java
+++ b/src/main/java/project/food/global/api/naver/NaverSearchService.java
@@ -28,8 +28,13 @@ public class NaverSearchService {
 
     private final RestTemplate restTemplate;
 
+    // Cloudflare 등 봇 차단이 강한 도메인 - 다운로드 시도 제외
+    private static final List<String> BLOCKED_DOMAINS = List.of(
+            "i.namu.wiki", "namu.wiki", "cloudflare"
+    );
+
     /**
-     * 음식점 이름으로 네이버 이미지 검색 후 첫 번째 이미지 byte[] 반환
+     * 음식점 이름으로 네이버 이미지 검색 후 다운로드 가능한 첫 이미지 byte[] 반환
      * 이미지가 없거나 실패하면 null 반환 (실패해도 맛집 저장은 계속 진행)
      */
     public byte[] searchRestaurantImage(String restaurantName) {
@@ -39,7 +44,7 @@ public class NaverSearchService {
             URI uri = UriComponentsBuilder
                     .fromHttpUrl(NAVER_IMAGE_SEARCH_URL)
                     .queryParam("query", restaurantName)
-                    .queryParam("display", 1)   // 첫 번째 이미지만
+                    .queryParam("display", 5)   // 여러 개 받아서 순차 시도
                     .queryParam("sort", "sim")  // 유사도순
                     .encode(StandardCharsets.UTF_8)
                     .build()
@@ -63,14 +68,18 @@ public class NaverSearchService {
                 return null;
             }
 
-            // link: 원본 이미지 URL (thumbnail은 search.pstatic.net 프록시라 서버 요청 차단됨)
-            String imageUrl = (String) items.get(0).get("link");
-            if (imageUrl == null) return null;
+            // 차단된 도메인은 스킵하고 다운로드 가능한 URL 순차 시도
+            for (Map item : items) {
+                String imageUrl = (String) item.get("link");
+                if (imageUrl == null) continue;
+                if (BLOCKED_DOMAINS.stream().anyMatch(imageUrl::contains)) continue;
 
-            log.debug("[NAVER][IMAGE] 이미지 URL 획득: query={}, url={}", restaurantName, imageUrl);
+                byte[] imageBytes = downloadImage(imageUrl);
+                if (imageBytes != null) return imageBytes;
+            }
 
-            // 이미지 다운로드
-            return downloadImage(imageUrl);
+            log.warn("[NAVER][IMAGE] 다운로드 가능한 이미지 없음: query={}", restaurantName);
+            return null;
 
         } catch (Exception e) {
             log.warn("[NAVER][IMAGE] 이미지 검색 실패 (스킵): query={}, error={}", restaurantName, e.getMessage());

--- a/src/main/java/project/food/global/common/CachedPage.java
+++ b/src/main/java/project/food/global/common/CachedPage.java
@@ -1,0 +1,24 @@
+package project.food.global.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+/**
+ * Redis 캐싱 가능한 Page 래퍼
+ * PageImpl은 Jackson 역직렬화 불가 → 이 클래스로 대체
+ */
+public class CachedPage<T> extends PageImpl<T> {
+
+    @JsonCreator
+    public CachedPage(
+            @JsonProperty("content") List<T> content,
+            @JsonProperty("number") int page,
+            @JsonProperty("size") int size,
+            @JsonProperty("totalElements") long totalElements) {
+        super(content, PageRequest.of(page, size), totalElements);
+    }
+}

--- a/src/main/java/project/food/global/config/RedisConfig.java
+++ b/src/main/java/project/food/global/config/RedisConfig.java
@@ -1,0 +1,47 @@
+package project.food.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.activateDefaultTyping(
+                objectMapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+        );
+
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+                .disableCachingNullValues();
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+}

--- a/src/main/java/project/food/global/config/SecurityConfig.java
+++ b/src/main/java/project/food/global/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"
                         ).permitAll()
+                        .requestMatchers("/api/members/logout").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/members").permitAll()
                         .requestMatchers(HttpMethod.GET,
                                 "/api/posts/**",

--- a/src/main/java/project/food/global/jwt/RefreshTokenService.java
+++ b/src/main/java/project/food/global/jwt/RefreshTokenService.java
@@ -1,0 +1,37 @@
+package project.food.global.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    private static final String KEY_PREFIX = "refresh:token:";
+
+    public void save(Long memberId, String refreshToken) {
+        redisTemplate.opsForValue().set(
+                KEY_PREFIX + memberId,
+                refreshToken,
+                Duration.ofMillis(refreshTokenExpiration)
+        );
+    }
+
+    public boolean isValid(Long memberId, String refreshToken) {
+        String stored = redisTemplate.opsForValue().get(KEY_PREFIX + memberId);
+        return refreshToken.equals(stored);
+    }
+
+    public void delete(Long memberId) {
+        redisTemplate.delete(KEY_PREFIX + memberId);
+    }
+}

--- a/src/main/java/project/food/global/redis/PostCountService.java
+++ b/src/main/java/project/food/global/redis/PostCountService.java
@@ -1,0 +1,68 @@
+package project.food.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostCountService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String VIEW_KEY = "view:count:";
+    private static final String LIKE_KEY = "like:count:";
+
+    // ── 조회수 ──────────────────────────────────────────
+
+    /** 조회수 1 증가 후 반환 */
+    public long incrementViewCount(Long postId) {
+        Long count = redisTemplate.opsForValue().increment(VIEW_KEY + postId);
+        return count != null ? count : 0L;
+    }
+
+    /** 조회수 반환 (없으면 DB 값으로 초기화) */
+    public long getViewCount(Long postId, int dbViewCount) {
+        String value = redisTemplate.opsForValue().get(VIEW_KEY + postId);
+        if (value != null) return Long.parseLong(value);
+        // Redis에 없으면 DB 값으로 초기화
+        redisTemplate.opsForValue().set(VIEW_KEY + postId, String.valueOf(dbViewCount));
+        return dbViewCount;
+    }
+
+    /** 게시글 삭제 시 Redis 키 제거 */
+    public void deleteViewCount(Long postId) {
+        redisTemplate.delete(VIEW_KEY + postId);
+    }
+
+    // ── 좋아요 수 ────────────────────────────────────────
+
+    /** 좋아요 수 1 증가 */
+    public long incrementLikeCount(Long postId) {
+        Long count = redisTemplate.opsForValue().increment(LIKE_KEY + postId);
+        return count != null ? count : 0L;
+    }
+
+    /** 좋아요 수 1 감소 (최소 0) */
+    public long decrementLikeCount(Long postId) {
+        Long count = redisTemplate.opsForValue().decrement(LIKE_KEY + postId);
+        if (count != null && count < 0) {
+            redisTemplate.opsForValue().set(LIKE_KEY + postId, "0");
+            return 0L;
+        }
+        return count != null ? count : 0L;
+    }
+
+    /** 좋아요 수 반환 (없으면 DB 값으로 초기화) */
+    public long getLikeCount(Long postId, long dbLikeCount) {
+        String value = redisTemplate.opsForValue().get(LIKE_KEY + postId);
+        if (value != null) return Long.parseLong(value);
+        redisTemplate.opsForValue().set(LIKE_KEY + postId, String.valueOf(dbLikeCount));
+        return dbLikeCount;
+    }
+
+    /** 게시글 삭제 시 Redis 키 제거 */
+    public void deleteLikeCount(Long postId) {
+        redisTemplate.delete(LIKE_KEY + postId);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,11 @@ spring:
     properties:
       hibernate:
   cache:
-    type: none
+    type: redis
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 server:
   port: 8080

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,9 +20,11 @@ spring:
         query.in_clause_parameter_padding: true
 
   cache:
-    type: caffeine
-    caffeine:
-      spec: maximumSize=1000,expireAfterWrite=600s
+    type: redis
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: 6379
 
   cloud:
     aws:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,4 +1,6 @@
 spring:
+  cache:
+    type: none
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MYSQL
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
## Summary
- Redis 의존성 추가 및 설정 (dev/prod/test)
- 게시글/맛집 목록 캐싱 (`@Cacheable`, TTL 10분)
- Refresh Token Redis 저장 + 로그아웃 API (`POST /api/members/logout`)
- 좋아요 수/조회수 Redis 카운터 (DB 쿼리 제거)
- docker-compose.dev.yml Redis 서비스 추가
