### PR TITLE
feat: 카카오 OAuth 로그인 및 Redis 캐시 역직렬화 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,7 @@ jobs:
               -e CORS_ALLOWED_ORIGINS="${{ secrets.CORS_ALLOWED_ORIGINS }}" \
               -e NAVER_API_CLIENT_ID=${{ secrets.NAVER_API_CLIENT_ID }} \
               -e NAVER_API_CLIENT_SECRET=${{ secrets.NAVER_API_CLIENT_SECRET }} \
+              -e KAKAO_OAUTH_REDIRECT_URI=${{ secrets.KAKAO_OAUTH_REDIRECT_URI }} \
               -e REDIS_HOST=localhost \
               --network host \
               ${{ secrets.ECR_REPOSITORY }}:latest

--- a/src/main/java/project/food/domain/member/controller/OAuthController.java
+++ b/src/main/java/project/food/domain/member/controller/OAuthController.java
@@ -1,0 +1,25 @@
+package project.food.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import project.food.domain.member.dto.LoginResponseDto;
+import project.food.domain.member.service.OAuthService;
+
+@Tag(name = "OAuth", description = "소셜 로그인 API")
+@RestController
+@RequestMapping("/api/oauth")
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final OAuthService oAuthService;
+
+    @Operation(summary = "카카오 로그인", description = "카카오 인가코드로 로그인합니다.")
+    @GetMapping("/kakao")
+    public ResponseEntity<LoginResponseDto> kakaoLogin(@RequestParam String code) {
+        LoginResponseDto response = oAuthService.kakaoLogin(code);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/project/food/domain/member/service/OAuthService.java
+++ b/src/main/java/project/food/domain/member/service/OAuthService.java
@@ -1,0 +1,104 @@
+package project.food.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.food.domain.member.dto.LoginResponseDto;
+import project.food.domain.member.dto.MemberResponseDto;
+import project.food.domain.member.entity.Member;
+import project.food.domain.member.repository.MemberRepository;
+import project.food.global.api.kakao.oauth.dto.KakaoTokenResponse;
+import project.food.global.api.kakao.oauth.dto.KakaoUserInfoResponse;
+import project.food.global.api.kakao.oauth.service.KakaoOAuthService;
+import project.food.global.exception.CustomException;
+import project.food.global.exception.ErrorCode;
+import project.food.global.jwt.JwtTokenProvider;
+import project.food.global.jwt.RefreshTokenService;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class OAuthService {
+
+    private final KakaoOAuthService kakaoOAuthService;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    /**
+     * 카카오 OAuth 로그인
+     * 1. 인가코드 → 카카오 액세스 토큰
+     * 2. 카카오 액세스 토큰 → 사용자 정보 (이메일, 닉네임)
+     * 3. DB에 회원 없으면 자동 가입, 있으면 로그인
+     * 4. JWT 발급
+     */
+    public LoginResponseDto kakaoLogin(String code) {
+        // 1. 인가코드로 카카오 액세스 토큰 발급
+        KakaoTokenResponse tokenResponse = kakaoOAuthService.getToken(code);
+
+        // 2. 카카오 액세스 토큰으로 사용자 정보 조회
+        KakaoUserInfoResponse userInfo = kakaoOAuthService.getUserInfo(tokenResponse.getAccessToken());
+
+        String email = userInfo.getEmail();
+        if (email == null) {
+            log.error("[KAKAO][OAUTH] 이메일 정보 없음: kakaoId={}", userInfo.getId());
+            throw new CustomException(ErrorCode.KAKAO_API_ERROR);
+        }
+
+        // 3. 이메일로 회원 조회 → 없으면 자동 가입
+        Member member = memberRepository.findByEmail(email)
+                .orElseGet(() -> registerOAuthMember(email, userInfo.getNickname()));
+
+        // 4. JWT 발급
+        String accessToken = jwtTokenProvider.createAccessToken(
+                member.getId(), member.getEmail(), member.getRole().getKey());
+        String refreshToken = jwtTokenProvider.createRefreshToken(
+                member.getId(), member.getRole().getKey());
+
+        refreshTokenService.save(member.getId(), refreshToken);
+
+        log.info("[KAKAO][OAUTH] 로그인 완료: memberId={}, email={}", member.getId(), email);
+
+        return LoginResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .member(MemberResponseDto.from(member))
+                .build();
+    }
+
+    /**
+     * OAuth 신규 회원 자동 가입
+     * - 비밀번호: UUID (로그인 불가, OAuth 전용)
+     * - 닉네임 중복 시 숫자 접미사 추가
+     */
+    private Member registerOAuthMember(String email, String kakaoNickname) {
+        String nickname = resolveUniqueNickname(kakaoNickname != null ? kakaoNickname : "카카오유저");
+        String dummyPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+
+        Member member = Member.builder()
+                .email(email)
+                .password(dummyPassword)
+                .name(nickname)
+                .nickname(nickname)
+                .build();
+
+        Member saved = memberRepository.save(member);
+        log.info("[KAKAO][OAUTH] 신규 회원 가입: memberId={}, email={}", saved.getId(), email);
+        return saved;
+    }
+
+    private String resolveUniqueNickname(String base) {
+        String nickname = base;
+        int suffix = 1;
+        while (memberRepository.existsByNickname(nickname)) {
+            nickname = base + suffix++;
+        }
+        return nickname;
+    }
+}

--- a/src/main/java/project/food/domain/restaurant/dto/RestaurantListItemResponse.java
+++ b/src/main/java/project/food/domain/restaurant/dto/RestaurantListItemResponse.java
@@ -1,7 +1,9 @@
 package project.food.domain.restaurant.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import project.food.domain.restaurant.entity.Restaurant;
 
 /**
@@ -10,6 +12,8 @@ import project.food.domain.restaurant.entity.Restaurant;
  */
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RestaurantListItemResponse {
 
     private Long id;         // 맛집 ID

--- a/src/main/java/project/food/domain/restaurant/dto/RestaurantRankResponse.java
+++ b/src/main/java/project/food/domain/restaurant/dto/RestaurantRankResponse.java
@@ -1,10 +1,14 @@
 package project.food.domain.restaurant.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RestaurantRankResponse {
     private Long id;
     private String name;

--- a/src/main/java/project/food/domain/restaurant/service/RestaurantService.java
+++ b/src/main/java/project/food/domain/restaurant/service/RestaurantService.java
@@ -68,7 +68,6 @@ public class RestaurantService {
      * @param restaurantId 맛집 ID
      * @return 맛집 상세 정보 (리뷰 포함)
      */
-    @Cacheable(value = "restaurant", key = "#restaurantId")
     public RestaurantDetailResponse getDetail(Long restaurantId) {
         // 맛집 조회
         Restaurant restaurant = restaurantRepository.findById(restaurantId)

--- a/src/main/java/project/food/global/api/kakao/oauth/dto/KakaoTokenResponse.java
+++ b/src/main/java/project/food/global/api/kakao/oauth/dto/KakaoTokenResponse.java
@@ -1,0 +1,22 @@
+package project.food.global.api.kakao.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+}

--- a/src/main/java/project/food/global/api/kakao/oauth/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/project/food/global/api/kakao/oauth/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,40 @@
+package project.food.global.api.kakao.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoResponse {
+
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+
+        private String email;
+
+        private Profile profile;
+
+        @Getter
+        @NoArgsConstructor
+        public static class Profile {
+            private String nickname;
+        }
+    }
+
+    public String getEmail() {
+        if (kakaoAccount == null) return null;
+        return kakaoAccount.getEmail();
+    }
+
+    public String getNickname() {
+        if (kakaoAccount == null || kakaoAccount.getProfile() == null) return null;
+        return kakaoAccount.getProfile().getNickname();
+    }
+}

--- a/src/main/java/project/food/global/api/kakao/oauth/service/KakaoOAuthService.java
+++ b/src/main/java/project/food/global/api/kakao/oauth/service/KakaoOAuthService.java
@@ -1,0 +1,75 @@
+package project.food.global.api.kakao.oauth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import project.food.global.api.kakao.oauth.dto.KakaoTokenResponse;
+import project.food.global.api.kakao.oauth.dto.KakaoUserInfoResponse;
+import project.food.global.exception.CustomException;
+import project.food.global.exception.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoOAuthService {
+
+    @Value("${kakao.api.key}")
+    private String clientId;
+
+    @Value("${kakao.oauth.redirect-uri}")
+    private String redirectUri;
+
+    private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final RestTemplate restTemplate;
+
+    /**
+     * 인가코드 → 카카오 액세스 토큰 교환
+     */
+    public KakaoTokenResponse getToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+                    TOKEN_URL, HttpMethod.POST, request, KakaoTokenResponse.class);
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("[KAKAO][OAUTH] 토큰 교환 실패: {}", e.getMessage());
+            throw new CustomException(ErrorCode.KAKAO_API_ERROR);
+        }
+    }
+
+    /**
+     * 카카오 액세스 토큰 → 사용자 정보 조회
+     */
+    public KakaoUserInfoResponse getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoUserInfoResponse> response = restTemplate.exchange(
+                    USER_INFO_URL, HttpMethod.GET, request, KakaoUserInfoResponse.class);
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("[KAKAO][OAUTH] 사용자 정보 조회 실패: {}", e.getMessage());
+            throw new CustomException(ErrorCode.KAKAO_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/project/food/global/common/CachedPage.java
+++ b/src/main/java/project/food/global/common/CachedPage.java
@@ -1,6 +1,7 @@
 package project.food.global.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -11,6 +12,7 @@ import java.util.List;
  * Redis 캐싱 가능한 Page 래퍼
  * PageImpl은 Jackson 역직렬화 불가 → 이 클래스로 대체
  */
+@JsonIgnoreProperties(value = {"pageable", "sort"}, ignoreUnknown = true)
 public class CachedPage<T> extends PageImpl<T> {
 
     @JsonCreator

--- a/src/main/java/project/food/global/common/CursorPageResponse.java
+++ b/src/main/java/project/food/global/common/CursorPageResponse.java
@@ -1,12 +1,16 @@
 package project.food.global.common;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CursorPageResponse<T> {
     private List<T> content;
     private String nextCursor;

--- a/src/main/java/project/food/global/config/RedisConfig.java
+++ b/src/main/java/project/food/global/config/RedisConfig.java
@@ -1,5 +1,7 @@
 package project.food.global.config;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -24,6 +26,7 @@ public class RedisConfig {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         objectMapper.activateDefaultTyping(
                 objectMapper.getPolymorphicTypeValidator(),
                 ObjectMapper.DefaultTyping.NON_FINAL

--- a/src/main/java/project/food/global/config/SecurityConfig.java
+++ b/src/main/java/project/food/global/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                                 "/api/members/refresh",
                                 "/api/members/check-email",
                                 "/api/members/check-nickname",
+                                "/api/oauth/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"
                         ).permitAll()

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -39,6 +39,8 @@ spring:
 kakao:
   api:
     key: ${KAKAO_API_KEY}
+  oauth:
+    redirect-uri: ${KAKAO_OAUTH_REDIRECT_URI}
 
 naver:
   api:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -38,6 +38,8 @@ cors:
 kakao:
   api:
     key: test-kakao-key
+  oauth:
+    redirect-uri: http://localhost:8080/oauth/kakao/callback
 
 naver:
   api:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,10 @@ management:
     health:
       show-details: when-authorized
 
+kakao:
+  oauth:
+    redirect-uri: ${kakao.oauth.redirect-uri}
+
 naver:
   api:
     client-id: ${naver.api.client-id}


### PR DESCRIPTION
## Summary

- 카카오 OAuth 로그인 구현 (인가코드 → 토큰 교환 → 사용자 정보 조회 → JWT 발급)
- Redis 캐시 역직렬화 오류 수정 (CachedPage pageable 필드, DTO 생성자 문제)
- 맛집 상세 조회(`getDetail`) 캐시 제거 (내부 `Page<>` 포함으로 직렬화 불가)

## Changes

### 카카오 OAuth
- `OAuthController`: `GET /api/oauth/kakao?code={code}` 엔드포인트
- `OAuthService`: 카카오 로그인 플로우 (신규 회원 자동 가입 포함)
- `KakaoOAuthService`: 카카오 토큰 교환, 사용자 정보 조회
- `SecurityConfig`: `/api/oauth/**` permitAll 추가

### Redis 캐시 수정
- `CachedPage`: `@JsonIgnoreProperties(value = {"pageable", "sort"})` 추가
- `RedisConfig`: ObjectMapper FIELD visibility `ANY` 설정 (private 필드 역직렬화)
- `RestaurantListItemResponse`, `RestaurantRankResponse`, `CursorPageResponse`: `@NoArgsConstructor`, `@AllArgsConstructor` 추가
- `RestaurantService.getDetail`: `@Cacheable` 제거

## Test plan

- [ ] 카카오 로그인 버튼 클릭 → 카카오 인증 → JWT 발급 확인
- [ ] 게시글 목록/맛집 목록 조회 후 Redis 캐시 저장 확인 (`redis-cli keys *`)
- [ ] 재조회 시 캐시 히트 확인 (DB 쿼리 없이 응답)
- [ ] 게시글 작성/수정/삭제 후 캐시 evict 확인